### PR TITLE
CallableParameterUseCaseInTypeContextInspection: fix typo in problem …

### DIFF
--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/CallableParameterUseCaseInTypeContextInspection.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/CallableParameterUseCaseInTypeContextInspection.java
@@ -28,7 +28,7 @@ import java.util.LinkedList;
 
 public class CallableParameterUseCaseInTypeContextInspection extends BasePhpInspection {
     private static final String strProblemNoSense = "Makes no sense, because it's always true according to annotations";
-    private static final String strProblemCheckViolatesDefinition = "Makes no sense, because this type in not defined in annotations";
+    private static final String strProblemCheckViolatesDefinition = "Makes no sense, because this type is not defined in annotations";
     private static final String strProblemAssignmentViolatesDefinition = "New value type (%s%) is not in annotated types";
 
     @NotNull


### PR DESCRIPTION
Fix typo in CallableParameterUseCaseInTypeContextInspection::strProblemCheckViolatesDefinition