### PR TITLE
prototype #186 Reports the usage of 'at' operator

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -612,6 +612,10 @@ This release brings new QFs, probable bugs inspections and fixes a new bunch of 
         shortName="DisallowWritingIntoStaticPropertiesInspection" displayName="Disallow writing into static properties"
         groupName="Code Style" enabledByDefault="false" level="WARNING"
         implementationClass="com.kalessil.phpStorm.phpInspectionsEA.inspectors.codeSmell.DisallowWritingIntoStaticPropertiesInspector"/>
+    <localInspection language="PHP" groupPath="PHP,Php Inspections (EA Extended)"
+        shortName="UsageOfSilenceOperatorInspection"               displayName="Usage of a silence operator"
+        groupName="Code Style"                                     enabledByDefault="false" level="WARNING"
+        implementationClass="com.kalessil.phpStorm.phpInspectionsEA.inspectors.codeSmell.UsageOfSilenceOperatorInspector"/>
 
 
 

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/UsageOfSilenceOperatorInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/UsageOfSilenceOperatorInspector.java
@@ -1,0 +1,61 @@
+package com.kalessil.phpStorm.phpInspectionsEA.inspectors.codeSmell;
+
+/*
+ * This file is part of the Php Inspections (EA Extended) package.
+ *
+ * (c) Vladimir Reznichenko <kalessil@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementVisitor;
+import com.jetbrains.php.lang.lexer.PhpTokenTypes;
+import com.jetbrains.php.lang.psi.PhpPsiUtil;
+import com.jetbrains.php.lang.psi.elements.FunctionReference;
+import com.jetbrains.php.lang.psi.elements.UnaryExpression;
+import com.jetbrains.php.lang.psi.visitors.PhpElementVisitor;
+import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class UsageOfSilenceOperatorInspector extends BasePhpInspection {
+    private static final String message = "Usage of a silence operator.";
+
+    private static final List<String> FUNCTIONS = Arrays.asList(
+            "\\unlink", "\\mkdir"
+    );
+
+    @NotNull
+    public String getShortName() {
+        return "UsageOfSilenceOperatorInspection";
+    }
+
+    @NotNull
+    public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder holder, boolean isOnTheFly) {
+        return new PhpElementVisitor() {
+            public void visitPhpUnaryExpression(UnaryExpression expr) {
+                PsiElement operation = expr.getOperation();
+                if (!PhpPsiUtil.isOfType(operation, PhpTokenTypes.opSILENCE)) {
+                    return;
+                }
+
+
+                PsiElement lastElement = expr.getLastChild();
+                if (lastElement instanceof FunctionReference) {
+                    String functionName = ((FunctionReference) lastElement).getFQN();
+                    if (FUNCTIONS.contains(functionName)) {
+                        return;
+                    }
+                }
+
+                holder.registerProblem(operation, message);
+            }
+        };
+    }
+
+}

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/UsageOfSilenceOperatorInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/UsageOfSilenceOperatorInspector.java
@@ -1,13 +1,5 @@
 package com.kalessil.phpStorm.phpInspectionsEA.inspectors.codeSmell;
 
-/*
- * This file is part of the Php Inspections (EA Extended) package.
- *
- * (c) Vladimir Reznichenko <kalessil@gmail.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
 
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.psi.PsiElement;
@@ -18,16 +10,27 @@ import com.jetbrains.php.lang.psi.elements.FunctionReference;
 import com.jetbrains.php.lang.psi.elements.UnaryExpression;
 import com.jetbrains.php.lang.psi.visitors.PhpElementVisitor;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
+import com.kalessil.phpStorm.phpInspectionsEA.utils.OpenapiTypesUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 import java.util.List;
 
+/*
+ * This file is part of the Php Inspections (EA Extended) package.
+ *
+ * (c) Funivan <alotofall@gmail.com>
+ * (c) Vladimir Reznichenko <kalessil@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 public class UsageOfSilenceOperatorInspector extends BasePhpInspection {
     private static final String message = "Usage of a silence operator.";
 
     private static final List<String> FUNCTIONS = Arrays.asList(
-            "\\unlink", "\\mkdir"
+            "\\unlink", "\\mkdir", "\\trigger_error"
     );
 
     @NotNull
@@ -39,15 +42,15 @@ public class UsageOfSilenceOperatorInspector extends BasePhpInspection {
     public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder holder, boolean isOnTheFly) {
         return new PhpElementVisitor() {
             public void visitPhpUnaryExpression(UnaryExpression expr) {
-                PsiElement operation = expr.getOperation();
+                final PsiElement operation = expr.getOperation();
                 if (!PhpPsiUtil.isOfType(operation, PhpTokenTypes.opSILENCE)) {
                     return;
                 }
 
 
-                PsiElement lastElement = expr.getLastChild();
-                if (lastElement instanceof FunctionReference) {
-                    String functionName = ((FunctionReference) lastElement).getFQN();
+                final PsiElement lastElement = expr.getValue();
+                if (OpenapiTypesUtil.isFunctionReference(lastElement)) {
+                    final String functionName = ((FunctionReference) lastElement).getFQN();
                     if (FUNCTIONS.contains(functionName)) {
                         return;
                     }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/UsageOfSilenceOperatorInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/UsageOfSilenceOperatorInspector.java
@@ -1,6 +1,7 @@
 package com.kalessil.phpStorm.phpInspectionsEA.inspectors.codeSmell;
 
 
+import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -56,7 +57,7 @@ public class UsageOfSilenceOperatorInspector extends BasePhpInspection {
                     }
                 }
 
-                holder.registerProblem(operation, message);
+                holder.registerProblem(operation, message, ProblemHighlightType.WEAK_WARNING);
             }
         };
     }

--- a/src/main/resources/inspectionDescriptions/UsageOfSilenceOperatorInspection.html
+++ b/src/main/resources/inspectionDescriptions/UsageOfSilenceOperatorInspection.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This inspection reports usages of a silence operator (@).
+</body>
+</html>

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/codeStyle/UsageOfSilenceOperatorInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/codeStyle/UsageOfSilenceOperatorInspectorTest.java
@@ -1,0 +1,13 @@
+package com.kalessil.phpStorm.phpInspectionsEA.codeStyle;
+
+import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase;
+import com.kalessil.phpStorm.phpInspectionsEA.inspectors.codeSmell.UsageOfSilenceOperatorInspector;
+
+
+public class UsageOfSilenceOperatorInspectorTest extends CodeInsightFixtureTestCase {
+    public void testIfFindsAllPatterns() {
+        myFixture.configureByFile("fixtures/codeStyle/usage-of-silence-operator.php");
+        myFixture.enableInspections(UsageOfSilenceOperatorInspector.class);
+        myFixture.testHighlighting(true, false, true);
+    }
+}

--- a/src/test/resources/fixtures/codeStyle/usage-of-silence-operator.php
+++ b/src/test/resources/fixtures/codeStyle/usage-of-silence-operator.php
@@ -21,7 +21,7 @@ namespace util {
 
 }
 
-namespace {
+namespace Test {
     use util\BonusCalculation;
     use function util\remove_file as unlink;
 
@@ -29,8 +29,10 @@ namespace {
     <weak_warning descr="Usage of a silence operator.">@</weak_warning>BonusCalculation::calculate(44);
 }
 
-
-/** false positive */
-@unlink('test.php');
-@mkdir('test/');
-@trigger_error('test/');
+namespace {
+    /** false positive */
+    @unlink('test.php');
+    @\unlink('test.php');
+    @mkdir('test/');
+    @trigger_error('test/');
+}

--- a/src/test/resources/fixtures/codeStyle/usage-of-silence-operator.php
+++ b/src/test/resources/fixtures/codeStyle/usage-of-silence-operator.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace {
+    <weak_warning descr="Usage of a silence operator.">@</weak_warning>file_get_contents('test.php');
+    echo <weak_warning descr="Usage of a silence operator.">@</weak_warning>$a;
+}
+
+
+namespace util {
+    function remove_file($file)
+    {
+
+    }
+
+}
+
+namespace {
+
+    use function util\remove_file as unlink;
+
+    <weak_warning descr="Usage of a silence operator.">@</weak_warning>unlink('test.php');
+}
+
+
+/** false positive */
+@unlink('test.php');
+@mkdir('test/');

--- a/src/test/resources/fixtures/codeStyle/usage-of-silence-operator.php
+++ b/src/test/resources/fixtures/codeStyle/usage-of-silence-operator.php
@@ -12,16 +12,25 @@ namespace util {
 
     }
 
+    class BonusCalculation
+    {
+        public static function calculate($value)
+        {
+        }
+    }
+
 }
 
 namespace {
-
+    use util\BonusCalculation;
     use function util\remove_file as unlink;
 
     <weak_warning descr="Usage of a silence operator.">@</weak_warning>unlink('test.php');
+    <weak_warning descr="Usage of a silence operator.">@</weak_warning>BonusCalculation::calculate(44);
 }
 
 
 /** false positive */
 @unlink('test.php');
 @mkdir('test/');
+@trigger_error('test/');


### PR DESCRIPTION
Todo
 - [x] Run tests. (I do not know why, but i cant run tests in my IDEA Ultimate. Something broken(()
 - [x] Decide what functions to add.

Here is the list of functions that are used with `at` operator from the symfony repository:


| Num | Function name                   |
| --- |:--------------------------------|
| 221 |   trigger_error                 |
| 82  |   unlink                        |
| 36  |   mkdir                         |
| 17  |   chmod                         |
| 12  |   rmdir                         |
| 9   |   rename                        |
| 8   |   fsockopen                     |
| 8   |   json_encode                   |
| 7   |   file_put_contents             |
| 6   |   fwrite                        |
| 6   |   fopen                         |
| 6   |   posix_isatty                  |
| 6   |   filemtime                     |
| 4   |   touch                         |
| 4   |   iconv                         |
| 3   |   is_readable                   |
| 3   |   fclose                        |
| 3   |   stream_select                 |
| 3   |   inet_pton                     |
| 3   |   symlink                       |
| 3   |   file_get_contents             |
| 2   |   proc_open                     |
| 2   |   tempnam                       |
| 2   |   ldap_bind                     |
| 2   |   ftruncate                     |
| 2   |   link                          |
| 2   |   get_resource_type             |
| 2   |   highlight_file                |
| 2   |   getenv                        |
| 2   |   socket_set_option             |
| 2   |   stream_socket_client          |
| 1   |   mysqli_options                |
| 1   |   ldap_set_option               |
| 1   |   ldap_get_option               |
| 1   |   socket_create                 |
| 1   |   fseek                         |
| 1   |   mb_check_encoding             |
| 1   |   getimagesize                  |
| 1   |   imagecreatefromstring         |
| 1   |   file_exists                   |
| 1   |   move_uploaded_file            |
| 1   |   iconv_strlen                  |
| 1   |   ldap_delete                   |
| 1   |   readlink                      |
| 1   |   pfsockopen                    |
| 1   |   lchown                        |
| 1   |   chown                         |
| 1   |   lchgrp                        |
| 1   |   chgrp                         |
| 1   |   class_exists                  |
| 1   |   opendir                       |
| 1   |   preg_replace                  |
| 1   |   fread                         |
| 1   |   ldap_rename                   |
| 1   |   ldap_modify                   |
| 1   |   sasql_pconnect                |
| 1   |   is_dir                        |
| 1   |   sasql_connect                 |
| 1   |   db2_prepare                   |
| 1   |   db2_execute                   |
| 1   |   db2_num_rows                  |
| 1   |   oci_execute                   |
| 1   |   oci_connect                   |
| 1   |   oci_pconnect                  |
| 1   |   proc_terminate                |
| 1   |   posix_kill                    |
| 1   |   apc_cache_info                |
| 1   |   is_executable                 |
| 1   |   ldap_add                      |
| 1   |   is_file                       |
| 1   |   fileatime                     |
| 1   |   cli_set_process_title         |
| 1   |   cli_get_process_title         |
| 1   |   mcrypt_create_iv              |
| 1   |   socket_recv                   |
| 1   |   opcache_compile_file          |
| 1   |   ldap_connect                  |
| 1   |   socket_connect                |
| 1   |   ldap_search                   |
| 1   |   ldap_get_entries              |
| 1   |   proc_get_status               |

