### PR TITLE
Adding a check to make sure that the use statement isn't a class trait

### DIFF
--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/languageConstructions/ClassConstantCanBeUsedInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/languageConstructions/ClassConstantCanBeUsedInspector.java
@@ -172,7 +172,8 @@ public class ClassConstantCanBeUsedInspector extends BasePhpInspection {
                     /* check all use-statements and use imported name for QF */
                     for (PhpUseList use : PsiTreeUtil.findChildrenOfType(file, PhpUseList.class)) {
                         /* do not process `function() use () {}` constructs or class traits */
-                        if (use.getParent() instanceof Function || use.getParent() instanceof PhpClass) {
+                        PsiElement parent = use.getParent();
+                        if (parent instanceof Function || parent instanceof PhpClass) {
                             continue;
                         }
 

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/languageConstructions/ClassConstantCanBeUsedInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/languageConstructions/ClassConstantCanBeUsedInspector.java
@@ -171,8 +171,8 @@ public class ClassConstantCanBeUsedInspector extends BasePhpInspection {
 
                     /* check all use-statements and use imported name for QF */
                     for (PhpUseList use : PsiTreeUtil.findChildrenOfType(file, PhpUseList.class)) {
-                        /* do not process `function() use () {}` constructs */
-                        if (use.getParent() instanceof Function) {
+                        /* do not process `function() use () {}` constructs or class traits */
+                        if (use.getParent() instanceof Function || use.getParent() instanceof PhpClass) {
                             continue;
                         }
 

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/lang/ClassConstantCanBeUsedInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/lang/ClassConstantCanBeUsedInspectorTest.java
@@ -1,7 +1,10 @@
 package com.kalessil.phpStorm.phpInspectionsEA.lang;
 
+import com.intellij.codeInsight.intention.IntentionAction;
 import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase;
 import com.kalessil.phpStorm.phpInspectionsEA.inspectors.languageConstructions.ClassConstantCanBeUsedInspector;
+
+import java.util.List;
 
 final public class ClassConstantCanBeUsedInspectorTest extends CodeInsightFixtureTestCase {
     public void testIfFindsAllPatterns() {
@@ -9,5 +12,20 @@ final public class ClassConstantCanBeUsedInspectorTest extends CodeInsightFixtur
         myFixture.configureByFile("fixtures/lang/classConstant/class-name-constant-ns.php");
         myFixture.enableInspections(ClassConstantCanBeUsedInspector.class);
         myFixture.testHighlighting(true, false, true);
+    }
+
+    public void testQuickFixOutput() {
+        myFixture.configureByFile("fixtures/lang/classConstant/class-in-the-same-namespace.php");
+        myFixture.configureByFile("fixtures/lang/classConstant/class-name-constant-ns.php");
+        myFixture.enableInspections(ClassConstantCanBeUsedInspector.class);
+        myFixture.testHighlighting(true, false, false);
+
+        List<IntentionAction> quickFixes = myFixture.getAllQuickFixes();
+        for (IntentionAction fix: quickFixes) {
+            myFixture.launchAction(fix);
+        }
+
+        myFixture.setTestDataPath("./");
+        myFixture.checkResultByFile("fixtures/lang/classConstant/class-name-constant-ns.fixed.php");
     }
 }


### PR DESCRIPTION
Fixes Issue #183 that I reported a week and a half ago

I'd love to contribute more, ~~~maybe write a test for this, but I couldn't run any of the tests. I got a weird message about not being able to find bundle messages.CssBundle when I tried to run the tests? I ended up figuring out how this worked and debugging by copying the popupBox you use for updates and using the title for debugging information~~~

Edit: I didn't follow your docs for setting up a dev environment (didn't even know they were there, thanks), so I didn't end up adding the CSS lib from PHPStorm, just the PHP and PHPStorm Lib (Because they were already in the settings, just pointing to a bad path)