### PR TITLE
Adding a test for IsEmptyUsage Inspector

### DIFF
--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/api/IsEmptyFunctionUsageInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/api/IsEmptyFunctionUsageInspectorTest.java
@@ -1,0 +1,17 @@
+package com.kalessil.phpStorm.phpInspectionsEA.api;
+
+import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase;
+import com.kalessil.phpStorm.phpInspectionsEA.inspectors.apiUsage.IsEmptyFunctionUsageInspector;
+
+final public class IsEmptyFunctionUsageInspectorTest extends CodeInsightFixtureTestCase {
+    public void testIfFindsAllPatterns() {
+        IsEmptyFunctionUsageInspector inspector = new IsEmptyFunctionUsageInspector();
+        inspector.SUGGEST_TO_USE_COUNT_CHECK = true;
+        inspector.REPORT_EMPTY_USAGE = true;
+        inspector.SUGGEST_TO_USE_NULL_COMPARISON = true;
+
+        myFixture.configureByFile("fixtures/api/empty-function.php");
+        myFixture.enableInspections(inspector);
+        myFixture.testHighlighting(true, false, true);
+    }
+}

--- a/src/test/resources/fixtures/api/empty-function.php
+++ b/src/test/resources/fixtures/api/empty-function.php
@@ -1,0 +1,21 @@
+<?php
+
+echo <warning descr="'0 === count($...)' construction should be used instead.">empty([])</warning>;
+
+function getNullableInt(?int $int) {
+    return $int;
+}
+
+function getNullableString(?string $string) {
+    return $string;
+}
+
+function isIntNull(?int $int) {
+    return <warning descr="You should probably use 'null === $...'.">empty($int)</warning>;
+}
+
+echo <warning descr="You should probably use 'null === $...'.">empty(getNullableInt())</warning>;
+echo <warning descr="You should probably use 'null === $...'.">empty(getNullableString())</warning>;
+
+echo <weak_warning descr="'empty(...)' counts too many values as empty, consider refactoring with type sensitive checks.">empty(1)</weak_warning>;
+echo <weak_warning descr="'empty(...)' counts too many values as empty, consider refactoring with type sensitive checks.">empty(null)</weak_warning>;


### PR DESCRIPTION
I've added a test, and in this test I've discovered a bug (That I'm going to make a shot at fixing). I'm not sure if it's a Php Inspections Bug, but the warning produced for `isIntNull` is wrong. It doesn't detect `$int` as an integer or a nullable for some reason, or it gives the weak warning of `empty` allowing too many things through.