### PR TITLE
[#188] OnlyWritesOnParameterInspector: check if referenced variables are use()d too

### DIFF
--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/OnlyWritesOnParameterInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/OnlyWritesOnParameterInspector.java
@@ -40,7 +40,8 @@ public class OnlyWritesOnParameterInspector extends BasePhpInspection {
         return "OnlyWritesOnParameterInspection";
     }
 
-    static private PhpAccessVariableInstruction[] getVariablesAccessInstructions(String parameterName, PhpScopeHolder objScopeHolder) {
+    @NotNull
+    static private PhpAccessVariableInstruction[] getVariablesAccessInstructions(@NotNull String parameterName, @NotNull PhpScopeHolder objScopeHolder) {
         PhpEntryPointInstruction objEntryPoint = objScopeHolder.getControlFlow().getEntryPoint();
         return PhpControlFlowUtil.getFollowingVariableAccessInstructions(objEntryPoint, parameterName, false);
     }

--- a/src/test/resources/fixtures/deadCode/parameters-writes-only.php
+++ b/src/test/resources/fixtures/deadCode/parameters-writes-only.php
@@ -2,19 +2,27 @@
 
 class Container {
     public function method1(array $in, array &$out, $log) {
-        return
+        $outc = 1;
+        $function =
             function
                 (array $inner, array &$outer)
                 use (
                     <weak_warning descr="The variable seems to be not used.">$in</weak_warning>,
-                    &$out,
+                    &<weak_warning descr="The variable seems to be not used.">$out</weak_warning>,
+                    &$outb,
+                    &$outc,
                     $log
                 )
             {
                 <weak_warning descr="Parameter/variable is overridden, but is never used or appears outside of the scope.">$inner[]</weak_warning> = '';
                 $outer []= '';
+                $outb = 1;
+                $outc++;
                 <weak_warning descr="Parameter/variable is overridden, but is never used or appears outside of the scope.">$log[]</weak_warning> = '';
             };
+
+        $function();
+        return $outb + $outc;
     }
 
     public function method2(array $in, array &$out) {

--- a/src/test/resources/fixtures/deadCode/parameters-writes-only.php
+++ b/src/test/resources/fixtures/deadCode/parameters-writes-only.php
@@ -2,27 +2,21 @@
 
 class Container {
     public function method1(array $in, array &$out, $log) {
-        $outc = 1;
-        $function =
+        return
             function
                 (array $inner, array &$outer)
                 use (
                     <weak_warning descr="The variable seems to be not used.">$in</weak_warning>,
-                    &<weak_warning descr="The variable seems to be not used.">$out</weak_warning>,
-                    &$outb,
-                    &$outc,
+                    &<weak_warning descr="The variable seems to be not used.">$outUnused</weak_warning>,
+                    &$outUsed,
                     $log
                 )
             {
                 <weak_warning descr="Parameter/variable is overridden, but is never used or appears outside of the scope.">$inner[]</weak_warning> = '';
                 $outer []= '';
-                $outb = 1;
-                $outc++;
+                $outUsed = 1;
                 <weak_warning descr="Parameter/variable is overridden, but is never used or appears outside of the scope.">$log[]</weak_warning> = '';
             };
-
-        $function();
-        return $outb + $outc;
     }
 
     public function method2(array $in, array &$out) {


### PR DESCRIPTION
What I did was basically removes the `if()` that avoids any validation over _referenced variables_, before it checks if it was used inside the function. 

Now the `analyzeAndReturnUsagesCount` will receives an observation that the passed variable is a _referenced variable_. It'll allows that this method checks if the variable is used internally, and independently of it be a reference, it'll returns 0 if it is never used (registering the problem). After that, if the variable is a referenced variable, then all method could be avoided (once that is useful only for local variables).

Added some tests to make sure that I don't broke anything.