### PR TITLE
[#221] Identify no side-effect statements

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -515,7 +515,13 @@ This release brings important bug-fixes and new inspections.
     <localInspection language="PHP" groupPath="PHP,Php Inspections (EA Extended)"
         shortName="UnusedGotoLabelInspection"                     displayName="Unused goto labels"
         groupName="Unused"                                        enabledByDefault="true" level="WEAK WARNING"
-        implementationClass="com.kalessil.phpStorm.phpInspectionsEA.inspectors.codeSmell.UnusedGotoLabelInspector"/>
+        implementationClass="com.kalessil.phpStorm.phpInspectionsEA.inspectors.codeSmell.UnusedGotoLabelInspector"/>v
+
+
+    <localInspection language="PHP" groupPath="PHP,Php Inspections (EA Extended)"
+        shortName="SideEffectAnalysisInspection"                  displayName="Call have no side-effect"
+        groupName="SideEffect"                                    enabledByDefault="false" level="WEAK WARNING"
+        implementationClass="com.kalessil.phpStorm.phpInspectionsEA.inspectors.semanticalAnalysis.SideEffectAnalysisInspector"/>
 
 
     <localInspection language="PHP" groupPath="PHP,Php Inspections (EA Extended)"

--- a/RULES.md
+++ b/RULES.md
@@ -64,6 +64,12 @@ Inspections Lists (Unused)
 | Unused               | SenselessMethodDuplicationInspection            | Child method is exactly the same                    | n/a | yes | n/a  | no  |
 | Unused               | UnusedGotoLabelInspection                       | Unused goto labels                                  | yes | yes | no   | no  |
 
+Inspections Lists (Side-Effect)
+---
+| Group                | Short Name                                      | Full Name                                           | QF  | UTs | QFTs | Doc |
+| :------------------- | :-------------------------------------------    | :-------------------------------------------------- | --: | --: | ---: | --: |
+| SideEffect           | SideEffectAnalysisInspector                     | Call can be removed because it have no side-effect  | n/a | yes | n/a  | no  |
+
 Inspections Lists (Compatibility)
 ---
 | Group                | Short Name                                      | Full Name                                           | QF  | UTs | QFTs | Doc |

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
@@ -30,8 +30,9 @@ import java.util.Collection;
 import java.util.HashMap;
 
 public class SideEffectAnalysisInspector extends BasePhpInspection {
-    private static final String messageNoSideEffect      = "This call can be removed because it have no side-effect.";
-    private static final String messageInvalidAnnotation = "Unsupported value on property @side-effect.";
+    private static final String messageNoSideEffect        = "This call can be removed because it have no side-effect.";
+    private static final String messageMultipleAnnotations = "Multiple declarations of @side-effect is not allowed.";
+    private static final String messageInvalidAnnotation   = "Unsupported value on property @side-effect.";
 
     private static final Key<Integer>    ReferenceIndex = Key.create("SideEffect.ReferenceIndex");
     private static final Key<SideEffect> SideEffectType = Key.create("SideEffect.Type");
@@ -198,6 +199,10 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
                     }
 
                     if (functionDocSideEffectTags.size() == 0) {
+                        return;
+                    }
+                    else if (functionDocSideEffectTags.size() > 1) {
+                        holder.registerProblem(functionDocComment, messageMultipleAnnotations, ProblemHighlightType.WEAK_WARNING);
                         return;
                     }
 

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
@@ -16,6 +16,7 @@ import com.jetbrains.php.lang.psi.elements.Function;
 import com.jetbrains.php.lang.psi.elements.FunctionReference;
 import com.jetbrains.php.lang.psi.elements.Parameter;
 import com.jetbrains.php.lang.psi.elements.impl.StatementImpl;
+import com.jetbrains.php.lang.psi.resolve.types.PhpType;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
 import org.jetbrains.annotations.NotNull;
@@ -39,6 +40,13 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
         if (function.hasRefParams()) {
             saveRefPosition(function);
             return SideEffect.POSSIBLE;
+        }
+
+        final Parameter[] functionParameters = function.getParameters();
+        for (Parameter functionParameter : functionParameters) {
+            if (functionParameter.getType().equals(PhpType.RESOURCE)) {
+                return SideEffect.EXTERNAL;
+            }
         }
 
         return SideEffect.NONE;

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
@@ -13,6 +13,7 @@ import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.openapi.util.Key;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import com.jetbrains.php.lang.documentation.phpdoc.psi.PhpDocComment;
 import com.jetbrains.php.lang.psi.elements.Function;
 import com.jetbrains.php.lang.psi.elements.FunctionReference;
@@ -24,6 +25,7 @@ import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -117,7 +119,19 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
             return SideEffect.POSSIBLE;
         }
 
-        return SideEffect.NONE;
+        SideEffect functionSideEffect = SideEffect.NONE;
+
+        final Collection<FunctionReference> functionReferencesCall = PsiTreeUtil.findChildrenOfType(function, FunctionReference.class);
+        for (FunctionReference functionReferenceCall : functionReferencesCall) {
+            final SideEffect functionReferenceSideEffect = identifySideEffect((Function) functionReferenceCall.resolve());
+
+            if (functionReferenceSideEffect == SideEffect.EXTERNAL ||
+                functionReferenceSideEffect == SideEffect.UNKNOW) {
+                return functionReferenceSideEffect;
+            }
+        }
+
+        return functionSideEffect;
     }
 
     private static void mapRefIndex(@NotNull final Function function) {

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
@@ -12,6 +12,7 @@ package com.kalessil.phpStorm.phpInspectionsEA.inspectors.semanticalAnalysis;
 import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.psi.PsiElementVisitor;
+import com.jetbrains.php.lang.psi.elements.Function;
 import com.jetbrains.php.lang.psi.elements.FunctionReference;
 import com.jetbrains.php.lang.psi.elements.Statement;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
@@ -24,10 +25,15 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
     private static final String message = "This call can be removed because it have no side-effect.";
     private static HashMap<String, SideEffect> mappedSideEffects = new HashMap<>();
 
-    private enum SideEffect {NONE, UNKNOW, INTERNAL, EXTERNAL}
+    private enum SideEffect {NONE, POSSIBLE, UNKNOW, INTERNAL, EXTERNAL}
 
     @NotNull
-    private static SideEffect identifySideEffect(FunctionReference functionReference) {
+    private static SideEffect identifySideEffect(@NotNull final FunctionReference functionReference) {
+        final Function function = (Function) functionReference.resolve();
+        if (null == function) {
+            return SideEffect.UNKNOW;
+        }
+
         return SideEffect.NONE;
     }
 
@@ -52,7 +58,7 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
     public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder holder, boolean isOnTheFly) {
         return new BasePhpElementVisitor() {
             @Override
-            public void visitPhpFunctionCall(FunctionReference functionReference) {
+            public void visitPhpFunctionCall(final FunctionReference functionReference) {
                 final SideEffect functionSideEffect = getIdentifiedSideEffect(functionReference);
 
                 if (functionSideEffect.equals(SideEffect.NONE) && functionReference.getParent() instanceof Statement) {

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
@@ -123,7 +123,12 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
 
         final Collection<FunctionReference> functionReferencesCall = PsiTreeUtil.findChildrenOfType(function, FunctionReference.class);
         for (FunctionReference functionReferenceCall : functionReferencesCall) {
-            final SideEffect functionReferenceSideEffect = identifySideEffect((Function) functionReferenceCall.resolve());
+            final Function functionReferenceCallResolved = (Function) functionReferenceCall.resolve();
+            if (functionReferenceCallResolved == function) {
+                continue;
+            }
+
+            final SideEffect functionReferenceSideEffect = identifySideEffect(functionReferenceCallResolved);
 
             if (functionReferenceSideEffect == SideEffect.EXTERNAL ||
                 functionReferenceSideEffect == SideEffect.UNKNOW) {

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
@@ -30,6 +30,57 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
 
     private enum SideEffect {NONE, POSSIBLE, UNKNOW, INTERNAL, EXTERNAL}
 
+    static {
+        mappedSideEffects.put("\\abort", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\apache_setenv", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\assert", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\call_user_func", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\call_user_func_array", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\chdir", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\chmod", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\class_exists", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\clearstatcache", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\closelog", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\copy", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\date_default_timezone_set", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\error_reporting", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\exec", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\extract", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\file_put_contents", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\forward_static_call", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\header", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\ini_set", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\json_decode", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\mkdir", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\mt_srand", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\ob_end_clean", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\ob_start", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\passthru", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\pcntl_alarm", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\pcntl_async_signals", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\pcntl_signal", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\posix_kill", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\putenv", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\register_shutdown_function", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\rename", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\restore_error_handler", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\set_error_handler", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\set_exception_handler", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\set_time_limit", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\sleep", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\spl_autoload_register", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\spl_autoload_unregister", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\sqlsrv_fetch", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\srand", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\syslog", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\touch", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\trigger_error", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\unlink", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\usleep", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\var_dump", SideEffect.EXTERNAL);
+        mappedSideEffects.put("\\xcache_clear_cache", SideEffect.EXTERNAL);
+    }
+
     @NotNull
     private static SideEffect identifySideEffect(@NotNull final FunctionReference functionReference) {
         final Function function = (Function) functionReference.resolve();

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
@@ -34,88 +34,88 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
     private static final String messageMultipleAnnotations = "Multiple declarations of @side-effect is not allowed.";
     private static final String messageInvalidAnnotation   = "Unsupported value on property @side-effect.";
 
-    private static final Key<Integer>    ReferenceIndex = Key.create("SideEffect.ReferenceIndex");
-    private static final Key<SideEffect> SideEffectType = Key.create("SideEffect.Type");
+    private static final Key<Integer>         ReferenceIndex = Key.create("SideEffect.ReferenceIndex");
+    private static final Key<SideEffect.Type> SideEffectType = Key.create("SideEffect.Type");
 
-    private static final HashMap<String, SideEffect> mappedPhpFunctions        = new HashMap<>();
-    private static final HashMap<String, SideEffect> sideEffectAnnotationTypes = new HashMap<>();
-
-    private enum SideEffect {NONE, POSSIBLE, UNKNOW, INTERNAL, EXTERNAL}
+    private static final HashMap<String, SideEffect.Type> mappedPhpFunctions        = new HashMap<>();
+    private static final HashMap<String, SideEffect.Type> sideEffectAnnotationTypes = new HashMap<>();
 
     static {
-        sideEffectAnnotationTypes.put("none", SideEffect.NONE);
-        sideEffectAnnotationTypes.put("possible", SideEffect.POSSIBLE);
-        sideEffectAnnotationTypes.put("unknow", SideEffect.UNKNOW);
-        sideEffectAnnotationTypes.put("internal", SideEffect.INTERNAL);
-        sideEffectAnnotationTypes.put("external", SideEffect.EXTERNAL);
+        sideEffectAnnotationTypes.put("none", SideEffect.Type.NONE);
+        sideEffectAnnotationTypes.put("possible", SideEffect.Type.POSSIBLE);
+        sideEffectAnnotationTypes.put("unknow", SideEffect.Type.UNKNOW);
+        sideEffectAnnotationTypes.put("internal", SideEffect.Type.INTERNAL);
+        sideEffectAnnotationTypes.put("external", SideEffect.Type.EXTERNAL);
 
-        mappedPhpFunctions.put("\\abort", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\apache_setenv", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\assert", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\call_user_func", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\call_user_func_array", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\chdir", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\chmod", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\class_exists", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\clearstatcache", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\closelog", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\copy", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\date_default_timezone_set", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\error_reporting", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\exec", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\extract", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\file_put_contents", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\forward_static_call", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\header", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\ini_set", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\json_decode", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\mkdir", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\mt_srand", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\ob_end_clean", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\ob_start", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\passthru", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\pcntl_alarm", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\pcntl_async_signals", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\pcntl_signal", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\posix_kill", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\putenv", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\register_shutdown_function", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\rename", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\restore_error_handler", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\set_error_handler", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\set_exception_handler", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\set_time_limit", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\sleep", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\spl_autoload_register", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\spl_autoload_unregister", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\sqlsrv_fetch", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\srand", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\syslog", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\touch", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\trigger_error", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\unlink", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\usleep", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\var_dump", SideEffect.EXTERNAL);
-        mappedPhpFunctions.put("\\xcache_clear_cache", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\abort", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\apache_setenv", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\assert", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\call_user_func", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\call_user_func_array", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\chdir", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\chmod", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\class_exists", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\clearstatcache", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\closelog", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\copy", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\date_default_timezone_set", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\error_reporting", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\exec", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\extract", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\file_put_contents", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\forward_static_call", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\header", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\ini_set", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\json_decode", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\mkdir", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\mt_srand", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\ob_end_clean", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\ob_start", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\passthru", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\pcntl_alarm", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\pcntl_async_signals", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\pcntl_signal", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\posix_kill", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\putenv", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\register_shutdown_function", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\rename", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\restore_error_handler", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\set_error_handler", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\set_exception_handler", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\set_time_limit", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\sleep", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\spl_autoload_register", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\spl_autoload_unregister", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\sqlsrv_fetch", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\srand", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\syslog", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\touch", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\trigger_error", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\unlink", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\usleep", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\var_dump", SideEffect.Type.EXTERNAL);
+        mappedPhpFunctions.put("\\xcache_clear_cache", SideEffect.Type.EXTERNAL);
     }
 
     @NotNull
-    private static SideEffect identifySideEffect(@Nullable final Function function) {
+    private static SideEffect.Type identifySideEffect(@Nullable final Function function) {
         if (null == function) {
-            return SideEffect.UNKNOW;
+            return SideEffect.Type.UNKNOW;
         }
 
         final Parameter[] functionParameters = function.getParameters();
         for (final Parameter functionParameter : functionParameters) {
             if (functionParameter.getType().equals(PhpType.RESOURCE)) {
-                return SideEffect.EXTERNAL;
+                return SideEffect.Type.EXTERNAL;
             }
         }
 
         if (function.hasRefParams()) {
             mapRefIndex(function);
-            return SideEffect.POSSIBLE;
+            return SideEffect.Type.POSSIBLE;
         }
+
+        SideEffect.Type functionSideEffect = SideEffect.Type.NONE;
 
         final Collection<FunctionReference> functionReferencesCall = PsiTreeUtil.findChildrenOfType(function, FunctionReference.class);
         for (final FunctionReference functionReferenceCall : functionReferencesCall) {
@@ -124,15 +124,18 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
                 continue;
             }
 
-            final SideEffect functionReferenceSideEffect = identifySideEffect(functionReferenceCallResolved);
+            final SideEffect.Type functionReferenceSideEffect = identifySideEffect(functionReferenceCallResolved);
 
-            if (functionReferenceSideEffect == SideEffect.EXTERNAL ||
-                functionReferenceSideEffect == SideEffect.UNKNOW) {
-                return functionReferenceSideEffect;
+            if (SideEffect.isPrecedenceHigherThan(functionReferenceSideEffect, functionSideEffect)) {
+                functionSideEffect = functionReferenceSideEffect;
+
+                if (SideEffect.isPrecedenceIsMax(functionSideEffect)) {
+                    return functionSideEffect;
+                }
             }
         }
 
-        return SideEffect.NONE;
+        return functionSideEffect;
     }
 
     private static void mapRefIndex(@NotNull final Function function) {
@@ -147,13 +150,13 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
     }
 
     @NotNull
-    private static SideEffect getIdentifiedSideEffect(@NotNull final FunctionReference functionReference) {
+    private static SideEffect.Type getIdentifiedSideEffect(@NotNull final FunctionReference functionReference) {
         final Function function = (Function) functionReference.resolve();
         if (null == function) {
-            return SideEffect.UNKNOW;
+            return SideEffect.Type.UNKNOW;
         }
 
-        SideEffect sideEffect = function.getUserData(SideEffectType);
+        SideEffect.Type sideEffect = function.getUserData(SideEffectType);
         if (null == sideEffect) {
             final String functionQualifiedName = function.getFQN();
 
@@ -237,10 +240,10 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
                 final Method classConstructor = classReferenceResolved instanceof Method
                     ? (Method) classReferenceResolved
                     : ((PhpClass) classReferenceResolved).getConstructor();
-                final SideEffect classConstructorSideEffect = identifySideEffect(classConstructor);
+                final SideEffect.Type classConstructorSideEffect = identifySideEffect(classConstructor);
 
-                if (classConstructorSideEffect.equals(SideEffect.NONE) ||
-                    classConstructorSideEffect.equals(SideEffect.UNKNOW)) {
+                if (classConstructorSideEffect.equals(SideEffect.Type.NONE) ||
+                    classConstructorSideEffect.equals(SideEffect.Type.UNKNOW)) {
                     registerSideEffectProblem(expression);
                 }
             }
@@ -254,12 +257,12 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
 
                 final Function function = (Function) functionReference.resolve();
                 if (null != function && functionReference.getParent().getClass().equals(StatementImpl.class)) {
-                    final SideEffect functionSideEffect = getIdentifiedSideEffect(functionReference);
+                    final SideEffect.Type functionSideEffect = getIdentifiedSideEffect(functionReference);
 
-                    if (functionSideEffect.equals(SideEffect.NONE)) {
+                    if (functionSideEffect.equals(SideEffect.Type.NONE)) {
                         registerSideEffectProblem(functionReference);
                     }
-                    else if (functionSideEffect.equals(SideEffect.POSSIBLE)) {
+                    else if (functionSideEffect.equals(SideEffect.Type.POSSIBLE)) {
                         final Integer functionParameterReferencePosition = function.getUserData(ReferenceIndex);
                         if (null != functionParameterReferencePosition &&
                             functionReference.getParameters().length < functionParameterReferencePosition) {
@@ -273,5 +276,33 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
                 holder.registerProblem(functionReference.getParent(), messageNoSideEffect, ProblemHighlightType.WEAK_WARNING);
             }
         };
+    }
+
+    private static class SideEffect {
+        final static Integer MAX_PRECEDENCE = 4;
+
+        final private static HashMap<Type, Integer> typePrecedence = new HashMap<>();
+
+        enum Type {NONE, POSSIBLE, UNKNOW, INTERNAL, EXTERNAL}
+
+        static {
+            typePrecedence.put(Type.NONE, MAX_PRECEDENCE - 4);
+            typePrecedence.put(Type.POSSIBLE, MAX_PRECEDENCE - 3);
+            typePrecedence.put(Type.INTERNAL, MAX_PRECEDENCE - 2);
+            typePrecedence.put(Type.EXTERNAL, MAX_PRECEDENCE - 1);
+            typePrecedence.put(Type.UNKNOW, MAX_PRECEDENCE);
+        }
+
+        static Integer getPrecedence(final Type type) {
+            return typePrecedence.get(type);
+        }
+
+        static Boolean isPrecedenceHigherThan(final Type newType, final Type currentType) {
+            return getPrecedence(newType) > getPrecedence(currentType);
+        }
+
+        static Boolean isPrecedenceIsMax(final Type type) {
+            return getPrecedence(type).equals(MAX_PRECEDENCE);
+        }
     }
 }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
@@ -14,6 +14,7 @@ import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.psi.PsiElementVisitor;
 import com.jetbrains.php.lang.psi.elements.Function;
 import com.jetbrains.php.lang.psi.elements.FunctionReference;
+import com.jetbrains.php.lang.psi.elements.Parameter;
 import com.jetbrains.php.lang.psi.elements.Statement;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
@@ -24,6 +25,7 @@ import java.util.HashMap;
 public class SideEffectAnalysisInspector extends BasePhpInspection {
     private static final String message = "This call can be removed because it have no side-effect.";
     private static HashMap<String, SideEffect> mappedSideEffects = new HashMap<>();
+    private static HashMap<String, Integer> mappedRefPositions = new HashMap<>();
 
     private enum SideEffect {NONE, POSSIBLE, UNKNOW, INTERNAL, EXTERNAL}
 
@@ -34,7 +36,23 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
             return SideEffect.UNKNOW;
         }
 
+        if (function.hasRefParams()) {
+            saveRefPosition(function);
+            return SideEffect.POSSIBLE;
+        }
+
         return SideEffect.NONE;
+    }
+
+    private static void saveRefPosition(@NotNull final Function function) {
+        final Parameter[] functionParameters = function.getParameters();
+
+        for (int functionParametersIndex = 0; functionParametersIndex < functionParameters.length; functionParametersIndex++) {
+            if (functionParameters[functionParametersIndex].isPassByRef()) {
+                mappedRefPositions.put(function.getFQN(), functionParametersIndex + 1);
+                break;
+            }
+        }
     }
 
     @NotNull
@@ -62,8 +80,17 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
                 final SideEffect functionSideEffect = getIdentifiedSideEffect(functionReference);
 
                 if (functionSideEffect.equals(SideEffect.NONE) && functionReference.getParent() instanceof Statement) {
-                    holder.registerProblem(functionReference.getParent(), message, ProblemHighlightType.WEAK_WARNING);
+                    registerProblem(functionReference);
                 }
+
+                if (functionSideEffect.equals(SideEffect.POSSIBLE) &&
+                    functionReference.getParameters().length < mappedRefPositions.get(functionReference.getFQN())) {
+                    registerProblem(functionReference);
+                }
+            }
+
+            private void registerProblem(@NotNull final FunctionReference functionReference) {
+                holder.registerProblem(functionReference.getParent(), message, ProblemHighlightType.WEAK_WARNING);
             }
         };
     }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
@@ -272,7 +272,7 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
                         }
                     }
                 }
-                if (!StatementImpl.class.isInstance(expressionParentClass)) {
+                if (!expressionParentClass.getClass().equals(StatementImpl.class)) {
                     return;
                 }
 

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
@@ -250,6 +250,11 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
                                     final PsiElement anchorParent = anchor.getParent();
 
                                     if (anchorParent instanceof MethodReference) {
+                                        if (!anchorParent.getParent().getClass().equals(StatementImpl.class)) {
+                                            variableSideEffect = SideEffect.Type.EXTERNAL;
+                                            break;
+                                        }
+
                                         final MethodReference anchorMethodReference  = (MethodReference) anchorParent;
                                         final Method          anchorMethod           = (Method) anchorMethodReference.resolve();
                                         final SideEffect.Type anchorMethodSideEffect = identifySideEffect(anchorMethod);
@@ -267,11 +272,13 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
 
                             if (variableSideEffect.equals(SideEffect.Type.NONE)) {
                                 registerSideEffectProblem(expressionParentClass);
-                                return;
                             }
+
+                            return;
                         }
                     }
                 }
+
                 if (!expressionParentClass.getClass().equals(StatementImpl.class)) {
                     return;
                 }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
@@ -233,8 +233,9 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
                 final Boolean    isAssignment          = expressionParentClass instanceof AssignmentExpressionImpl;
 
                 if (isAssignment) {
-                    final Variable variable = (Variable) ((AssignmentExpression) expressionParentClass).getVariable();
-                    if (null != variable) {
+                    final PsiElement expressionParentVariable = ((AssignmentExpression) expressionParentClass).getVariable();
+                    if (expressionParentVariable instanceof Variable) {
+                        final Variable       variable              = (Variable) expressionParentVariable;
                         final PhpScopeHolder expressionScopeHolder = PsiTreeUtil.getParentOfType(expression, PhpScopeHolder.class);
                         if (null != expressionScopeHolder) {
                             final PhpEntryPointInstruction scopeEntryPoint    = expressionScopeHolder.getControlFlow().getEntryPoint();

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
@@ -11,6 +11,7 @@ package com.kalessil.phpStorm.phpInspectionsEA.inspectors.semanticalAnalysis;
 
 import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.openapi.util.Key;
 import com.intellij.psi.PsiElementVisitor;
 import com.jetbrains.php.lang.psi.elements.Function;
 import com.jetbrains.php.lang.psi.elements.FunctionReference;
@@ -24,61 +25,64 @@ import org.jetbrains.annotations.NotNull;
 import java.util.HashMap;
 
 public class SideEffectAnalysisInspector extends BasePhpInspection {
-    private static final String                      message            = "This call can be removed because it have no side-effect.";
-    private static       HashMap<String, SideEffect> mappedSideEffects  = new HashMap<>();
-    private static       HashMap<String, Integer>    mappedRefPositions = new HashMap<>();
+    private static final String message = "This call can be removed because it have no side-effect.";
+
+    private static final Key<SideEffect> SideEffectType = Key.create("SideEffect.Type");
+
+    private static HashMap<String, SideEffect> mappedPhpFunctions = new HashMap<>();
+    private static HashMap<String, Integer>    mappedRefPositions = new HashMap<>();
 
     private enum SideEffect {NONE, POSSIBLE, UNKNOW, INTERNAL, EXTERNAL}
 
     static {
-        mappedSideEffects.put("\\abort", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\apache_setenv", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\assert", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\call_user_func", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\call_user_func_array", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\chdir", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\chmod", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\class_exists", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\clearstatcache", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\closelog", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\copy", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\date_default_timezone_set", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\error_reporting", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\exec", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\extract", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\file_put_contents", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\forward_static_call", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\header", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\ini_set", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\json_decode", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\mkdir", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\mt_srand", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\ob_end_clean", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\ob_start", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\passthru", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\pcntl_alarm", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\pcntl_async_signals", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\pcntl_signal", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\posix_kill", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\putenv", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\register_shutdown_function", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\rename", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\restore_error_handler", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\set_error_handler", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\set_exception_handler", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\set_time_limit", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\sleep", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\spl_autoload_register", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\spl_autoload_unregister", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\sqlsrv_fetch", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\srand", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\syslog", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\touch", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\trigger_error", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\unlink", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\usleep", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\var_dump", SideEffect.EXTERNAL);
-        mappedSideEffects.put("\\xcache_clear_cache", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\abort", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\apache_setenv", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\assert", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\call_user_func", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\call_user_func_array", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\chdir", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\chmod", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\class_exists", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\clearstatcache", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\closelog", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\copy", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\date_default_timezone_set", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\error_reporting", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\exec", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\extract", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\file_put_contents", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\forward_static_call", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\header", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\ini_set", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\json_decode", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\mkdir", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\mt_srand", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\ob_end_clean", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\ob_start", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\passthru", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\pcntl_alarm", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\pcntl_async_signals", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\pcntl_signal", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\posix_kill", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\putenv", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\register_shutdown_function", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\rename", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\restore_error_handler", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\set_error_handler", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\set_exception_handler", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\set_time_limit", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\sleep", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\spl_autoload_register", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\spl_autoload_unregister", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\sqlsrv_fetch", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\srand", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\syslog", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\touch", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\trigger_error", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\unlink", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\usleep", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\var_dump", SideEffect.EXTERNAL);
+        mappedPhpFunctions.put("\\xcache_clear_cache", SideEffect.EXTERNAL);
     }
 
     @NotNull
@@ -115,12 +119,24 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
     }
 
     @NotNull
-    private static SideEffect getIdentifiedSideEffect(@NotNull final FunctionReference functionReference, @NotNull final String functionQualifiedName) {
-        if (!mappedSideEffects.containsKey(functionQualifiedName)) {
-            mappedSideEffects.put(functionQualifiedName, identifySideEffect(functionReference));
+    private static SideEffect getIdentifiedSideEffect(@NotNull final FunctionReference functionReference) {
+        final Function function = (Function) functionReference.resolve();
+        if (null == function) {
+            return SideEffect.UNKNOW;
         }
 
-        return mappedSideEffects.get(functionQualifiedName);
+        SideEffect sideEffect = function.getUserData(SideEffectType);
+        if (null == sideEffect) {
+            final String functionQualifiedName = function.getFQN();
+
+            sideEffect = mappedPhpFunctions.containsKey(functionQualifiedName)
+                ? mappedPhpFunctions.get(functionQualifiedName)
+                : identifySideEffect(functionReference);
+
+            function.putUserData(SideEffectType, sideEffect);
+        }
+
+        return sideEffect;
     }
 
     @NotNull
@@ -142,7 +158,7 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
                 final Function function = (Function) functionReference.resolve();
                 if (null != function && functionReference.getParent().getClass().equals(StatementImpl.class)) {
                     final String     functionQualifiedName = function.getFQN();
-                    final SideEffect functionSideEffect    = getIdentifiedSideEffect(functionReference, functionQualifiedName);
+                    final SideEffect functionSideEffect    = getIdentifiedSideEffect(functionReference);
 
                     if (functionSideEffect.equals(SideEffect.NONE)) {
                         registerProblem(functionReference);

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
@@ -37,10 +37,10 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
     private static final Key<Integer>    ReferenceIndex = Key.create("SideEffect.ReferenceIndex");
     private static final Key<SideEffect> SideEffectType = Key.create("SideEffect.Type");
 
-    private static HashMap<String, SideEffect> mappedPhpFunctions        = new HashMap<>();
-    private static HashMap<String, SideEffect> sideEffectAnnotationTypes = new HashMap<>();
+    private static final HashMap<String, SideEffect> mappedPhpFunctions        = new HashMap<>();
+    private static final HashMap<String, SideEffect> sideEffectAnnotationTypes = new HashMap<>();
 
-    private static Pattern sideEffectAnnotationPattern = Pattern.compile("(?:^\\s*\\*|^\\/\\*{2})\\s*@side-effect\\s*(?<type>\\w+)\\s*(?:$|\\*\\/)", Pattern.MULTILINE);
+    private static final Pattern sideEffectAnnotationPattern = Pattern.compile("(?:^\\s*\\*|^\\/\\*{2})\\s*@side-effect\\s*(?<type>\\w+)\\s*(?:$|\\*\\/)", Pattern.MULTILINE);
 
     private enum SideEffect {NONE, POSSIBLE, UNKNOW, INTERNAL, EXTERNAL}
 
@@ -108,7 +108,7 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
         }
 
         final Parameter[] functionParameters = function.getParameters();
-        for (Parameter functionParameter : functionParameters) {
+        for (final Parameter functionParameter : functionParameters) {
             if (functionParameter.getType().equals(PhpType.RESOURCE)) {
                 return SideEffect.EXTERNAL;
             }
@@ -119,10 +119,8 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
             return SideEffect.POSSIBLE;
         }
 
-        SideEffect functionSideEffect = SideEffect.NONE;
-
         final Collection<FunctionReference> functionReferencesCall = PsiTreeUtil.findChildrenOfType(function, FunctionReference.class);
-        for (FunctionReference functionReferenceCall : functionReferencesCall) {
+        for (final FunctionReference functionReferenceCall : functionReferencesCall) {
             final Function functionReferenceCallResolved = (Function) functionReferenceCall.resolve();
             if (functionReferenceCallResolved == function) {
                 continue;
@@ -136,7 +134,7 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
             }
         }
 
-        return functionSideEffect;
+        return SideEffect.NONE;
     }
 
     private static void mapRefIndex(@NotNull final Function function) {
@@ -178,17 +176,17 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
 
     @NotNull
     @Override
-    public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder holder, boolean isOnTheFly) {
+    public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder holder, final boolean isOnTheFly) {
         return new BasePhpElementVisitor() {
             @Override
-            public void visitPhpFunction(Function function) {
+            public void visitPhpFunction(final Function function) {
                 function.putUserData(SideEffectType, identifySideEffect(function));
                 mapRefIndex(function);
                 parseSideEffectAnnotation(function);
             }
 
             // TODO: Should have a way to improve this part with some OpenAPI method for read DocComment @side-effect.
-            private void parseSideEffectAnnotation(@NotNull Function function) {
+            private void parseSideEffectAnnotation(@NotNull final Function function) {
                 final PhpDocComment functionDocComment = function.getDocComment();
                 if (null != functionDocComment) {
                     final String  functionDocCommentText    = functionDocComment.getText();

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
@@ -26,12 +26,12 @@ import org.jetbrains.annotations.Nullable;
 import java.util.HashMap;
 
 public class SideEffectAnalysisInspector extends BasePhpInspection {
-    private static final String message = "This call can be removed because it have no side-effect.";
+    private static final String messageNoSideEffect      = "This call can be removed because it have no side-effect.";
 
     private static final Key<Integer>    ReferenceIndex = Key.create("SideEffect.ReferenceIndex");
     private static final Key<SideEffect> SideEffectType = Key.create("SideEffect.Type");
 
-    private static HashMap<String, SideEffect> mappedPhpFunctions = new HashMap<>();
+    private static HashMap<String, SideEffect> mappedPhpFunctions        = new HashMap<>();
 
     private enum SideEffect {NONE, POSSIBLE, UNKNOW, INTERNAL, EXTERNAL}
 
@@ -160,20 +160,20 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
                     final SideEffect functionSideEffect = getIdentifiedSideEffect(functionReference);
 
                     if (functionSideEffect.equals(SideEffect.NONE)) {
-                        registerProblem(functionReference);
+                        registerSideEffectProblem(functionReference);
                     }
                     else if (functionSideEffect.equals(SideEffect.POSSIBLE)) {
                         final Integer functionParameterReferencePosition = function.getUserData(ReferenceIndex);
                         if (null != functionParameterReferencePosition &&
                             functionReference.getParameters().length < functionParameterReferencePosition) {
-                            registerProblem(functionReference);
+                            registerSideEffectProblem(functionReference);
                         }
                     }
                 }
             }
 
-            private void registerProblem(@NotNull final FunctionReference functionReference) {
-                holder.registerProblem(functionReference.getParent(), message, ProblemHighlightType.WEAK_WARNING);
+            private void registerSideEffectProblem(@NotNull final FunctionReference functionReference) {
+                holder.registerProblem(functionReference.getParent(), messageNoSideEffect, ProblemHighlightType.WEAK_WARNING);
             }
         };
     }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
@@ -179,7 +179,7 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
     public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder holder, final boolean isOnTheFly) {
         return new BasePhpElementVisitor() {
             @Override
-            public void visitPhpFunction(final Function function) {
+            public void visitPhpFunction(@NotNull final Function function) {
                 function.putUserData(SideEffectType, identifySideEffect(function));
                 mapRefIndex(function);
                 parseSideEffectAnnotation(function);
@@ -205,7 +205,11 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
             }
 
             @Override
-            public void visitPhpNewExpression(final NewExpression expression) {
+            public void visitPhpNewExpression(@NotNull final NewExpression expression) {
+                if (!expression.getParent().getClass().equals(StatementImpl.class)) {
+                    return;
+                }
+
                 final ClassReference classReference = expression.getClassReference();
                 if (null == classReference) {
                     return;

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
@@ -83,6 +83,11 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
         return new BasePhpElementVisitor() {
             @Override
             public void visitPhpFunctionCall(final FunctionReference functionReference) {
+                final String functionSimplifiedName = functionReference.getName();
+                if (null != functionSimplifiedName && functionSimplifiedName.isEmpty()) {
+                    return;
+                }
+
                 final Function function = (Function) functionReference.resolve();
                 if (null != function && functionReference.getParent().getClass().equals(StatementImpl.class)) {
                     final String     functionQualifiedName = function.getFQN();

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
@@ -37,16 +37,16 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
             return SideEffect.UNKNOW;
         }
 
-        if (function.hasRefParams()) {
-            saveRefPosition(function);
-            return SideEffect.POSSIBLE;
-        }
-
         final Parameter[] functionParameters = function.getParameters();
         for (Parameter functionParameter : functionParameters) {
             if (functionParameter.getType().equals(PhpType.RESOURCE)) {
                 return SideEffect.EXTERNAL;
             }
+        }
+
+        if (function.hasRefParams()) {
+            saveRefPosition(function);
+            return SideEffect.POSSIBLE;
         }
 
         return SideEffect.NONE;

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
@@ -79,14 +79,13 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
             public void visitPhpFunctionCall(final FunctionReference functionReference) {
                 final SideEffect functionSideEffect = getIdentifiedSideEffect(functionReference);
 
-                if (functionSideEffect.equals(SideEffect.NONE) &&
-                    functionReference.getParent().getClass().equals(StatementImpl.class)) {
-                    registerProblem(functionReference);
-                }
-
-                if (functionSideEffect.equals(SideEffect.POSSIBLE) &&
-                    functionReference.getParameters().length < mappedRefPositions.get(functionReference.getFQN())) {
-                    registerProblem(functionReference);
+                if (functionReference.getParent().getClass().equals(StatementImpl.class)) {
+                    if (functionSideEffect.equals(SideEffect.NONE)) {
+                        registerProblem(functionReference);
+                    } else if (functionSideEffect.equals(SideEffect.POSSIBLE) &&
+                        functionReference.getParameters().length < mappedRefPositions.get(functionReference.getFQN())) {
+                        registerProblem(functionReference);
+                    }
                 }
             }
 

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
@@ -21,6 +21,7 @@ import com.jetbrains.php.lang.psi.resolve.types.PhpType;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 
@@ -86,8 +87,7 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
     }
 
     @NotNull
-    private static SideEffect identifySideEffect(@NotNull final FunctionReference functionReference) {
-        final Function function = (Function) functionReference.resolve();
+    private static SideEffect identifySideEffect(@Nullable final Function function) {
         if (null == function) {
             return SideEffect.UNKNOW;
         }
@@ -131,7 +131,7 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
 
             sideEffect = mappedPhpFunctions.containsKey(functionQualifiedName)
                 ? mappedPhpFunctions.get(functionQualifiedName)
-                : identifySideEffect(functionReference);
+                : identifySideEffect((Function) functionReference.resolve());
 
             function.putUserData(SideEffectType, sideEffect);
         }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
@@ -1,0 +1,64 @@
+package com.kalessil.phpStorm.phpInspectionsEA.inspectors.semanticalAnalysis;
+
+/*
+ * This file is part of the Php Inspections (EA Extended) package.
+ *
+ * (c) Vladimir Reznichenko <kalessil@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import com.intellij.codeInspection.ProblemHighlightType;
+import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.psi.PsiElementVisitor;
+import com.jetbrains.php.lang.psi.elements.FunctionReference;
+import com.jetbrains.php.lang.psi.elements.Statement;
+import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
+import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+
+public class SideEffectAnalysisInspector extends BasePhpInspection {
+    private static final String message = "This call can be removed because it have no side-effect.";
+    private static HashMap<String, SideEffect> mappedSideEffects = new HashMap<>();
+
+    private enum SideEffect {NONE, UNKNOW, INTERNAL, EXTERNAL}
+
+    @NotNull
+    private static SideEffect identifySideEffect(FunctionReference functionReference) {
+        return SideEffect.NONE;
+    }
+
+    @NotNull
+    private static SideEffect getIdentifiedSideEffect(@NotNull final FunctionReference functionReference) {
+        final String functionFQN = functionReference.getFQN();
+
+        if (!mappedSideEffects.containsKey(functionFQN)) {
+            mappedSideEffects.put(functionFQN, identifySideEffect(functionReference));
+        }
+
+        return mappedSideEffects.get(functionFQN);
+    }
+
+    @NotNull
+    public String getShortName() {
+        return "SideEffectAnalysisInspector";
+    }
+
+    @NotNull
+    @Override
+    public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder holder, boolean isOnTheFly) {
+        return new BasePhpElementVisitor() {
+            @Override
+            public void visitPhpFunctionCall(FunctionReference functionReference) {
+                final SideEffect functionSideEffect = getIdentifiedSideEffect(functionReference);
+
+                if (functionSideEffect.equals(SideEffect.NONE) && functionReference.getParent() instanceof Statement) {
+                    holder.registerProblem(functionReference.getParent(), message, ProblemHighlightType.WEAK_WARNING);
+                }
+            }
+        };
+    }
+}

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/SideEffectAnalysisInspector.java
@@ -15,7 +15,7 @@ import com.intellij.psi.PsiElementVisitor;
 import com.jetbrains.php.lang.psi.elements.Function;
 import com.jetbrains.php.lang.psi.elements.FunctionReference;
 import com.jetbrains.php.lang.psi.elements.Parameter;
-import com.jetbrains.php.lang.psi.elements.Statement;
+import com.jetbrains.php.lang.psi.elements.impl.StatementImpl;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
 import org.jetbrains.annotations.NotNull;
@@ -79,7 +79,8 @@ public class SideEffectAnalysisInspector extends BasePhpInspection {
             public void visitPhpFunctionCall(final FunctionReference functionReference) {
                 final SideEffect functionSideEffect = getIdentifiedSideEffect(functionReference);
 
-                if (functionSideEffect.equals(SideEffect.NONE) && functionReference.getParent() instanceof Statement) {
+                if (functionSideEffect.equals(SideEffect.NONE) &&
+                    functionReference.getParent().getClass().equals(StatementImpl.class)) {
                     registerProblem(functionReference);
                 }
 

--- a/src/main/resources/inspectionDescriptions/SideEffectAnalysisInspector.html
+++ b/src/main/resources/inspectionDescriptions/SideEffectAnalysisInspector.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Reports when called method or function have no side-effect.
+</body>
+</html>

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/deadCode/SideEffectAnalysisInspectionTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/deadCode/SideEffectAnalysisInspectionTest.java
@@ -1,0 +1,12 @@
+package com.kalessil.phpStorm.phpInspectionsEA.deadCode;
+
+import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase;
+import com.kalessil.phpStorm.phpInspectionsEA.inspectors.semanticalAnalysis.SideEffectAnalysisInspector;
+
+final public class SideEffectAnalysisInspectionTest extends CodeInsightFixtureTestCase {
+    public void testIfFindsAllSideEffects() {
+        myFixture.configureByFile("fixtures/deadCode/side-effects.php");
+        myFixture.enableInspections(SideEffectAnalysisInspector.class);
+        myFixture.testHighlighting(true, false, true);
+    }
+}

--- a/src/test/resources/fixtures/deadCode/side-effects.php
+++ b/src/test/resources/fixtures/deadCode/side-effects.php
@@ -70,3 +70,9 @@ function sumSideEffectUnknow() {
     return unresolvedFunction();
 }
 sumSideEffectUnknow();
+
+
+function factorial(){
+    return factorial();
+}
+<weak_warning descr="This call can be removed because it have no side-effect.">factorial();</weak_warning>

--- a/src/test/resources/fixtures/deadCode/side-effects.php
+++ b/src/test/resources/fixtures/deadCode/side-effects.php
@@ -1,5 +1,7 @@
 <?php
 
+sideEffectUnknow();
+
 function sideEffectNone($number = null) {
 }
 

--- a/src/test/resources/fixtures/deadCode/side-effects.php
+++ b/src/test/resources/fixtures/deadCode/side-effects.php
@@ -100,6 +100,7 @@ class SideEffectNone_WithConstructor {
 class SideEffectNone_WithoutConstructor {}
 <weak_warning descr="This call can be removed because it have no side-effect.">new SideEffectNone_WithoutConstructor;</weak_warning>
 <weak_warning descr="This call can be removed because it have no side-effect.">$sideEffectNone_WithoutConstructor = new SideEffectNone_WithoutConstructor;</weak_warning>
+return new SideEffectNone_WithoutConstructor;
 
 
 class SideEffect_FullExample {

--- a/src/test/resources/fixtures/deadCode/side-effects.php
+++ b/src/test/resources/fixtures/deadCode/side-effects.php
@@ -52,3 +52,21 @@ function invalidSinglelineAnnotation(){
 function sleep() {
 }
 sleep();
+
+
+function sumSideEffectNone($a, $b) {
+    return $a + $b;
+}
+<weak_warning descr="This call can be removed because it have no side-effect.">sumSideEffectNone();</weak_warning>
+
+
+function sumSideEffectExternal() {
+    return touch();
+}
+sumSideEffectExternal();
+
+
+function sumSideEffectUnknow() {
+    return unresolvedFunction();
+}
+sumSideEffectUnknow();

--- a/src/test/resources/fixtures/deadCode/side-effects.php
+++ b/src/test/resources/fixtures/deadCode/side-effects.php
@@ -8,6 +8,12 @@ function sideEffectNone($number = null) {
 <weak_warning descr="This call can be removed because it have no side-effect.">sideEffectNone();</weak_warning>
 <weak_warning descr="This call can be removed because it have no side-effect.">sideEffectNone(1);</weak_warning>
 
+if (sideEffectNone()) {
+    <weak_warning descr="This call can be removed because it have no side-effect.">sideEffectNone(sideEffectNone());</weak_warning>
+    echo sideEffectNone();
+    return sideEffectNone();
+}
+
 function sideEffectPossible($arg1, &$arg2 = null) {
 }
 

--- a/src/test/resources/fixtures/deadCode/side-effects.php
+++ b/src/test/resources/fixtures/deadCode/side-effects.php
@@ -35,6 +35,11 @@ $shouldNotConsider = function () {
 };
 $shouldNotConsider();
 
+
+/** No annotation */
+function noAnnotation() {
+}
+
 <weak_warning descr="Unsupported value on property @side-effect.">/**
  * @side-effect invalid
  */</weak_warning>
@@ -52,7 +57,6 @@ function invalidSinglelineAnnotation(){
 function sleep() {
 }
 sleep();
-
 
 function sumSideEffectNone($a, $b) {
     return $a + $b;

--- a/src/test/resources/fixtures/deadCode/side-effects.php
+++ b/src/test/resources/fixtures/deadCode/side-effects.php
@@ -25,7 +25,7 @@ if (sideEffectPossible()) {
 }
 
 
-function sideEffectExternalResource(resource $resource) {
+function sideEffectExternalResource(resource $resource, &$possible = null) {
 }
 
 sideEffectExternalResource();

--- a/src/test/resources/fixtures/deadCode/side-effects.php
+++ b/src/test/resources/fixtures/deadCode/side-effects.php
@@ -107,3 +107,5 @@ class SideEffect_FullExample {
 }
 <weak_warning descr="This call can be removed because it have no side-effect.">$sideEffect_FullExample = new SideEffect_FullExample;</weak_warning>
 $sideEffect_FullExample->calculate();
+
+(new stdClass)->field = new SideEffect_FullExample();

--- a/src/test/resources/fixtures/deadCode/side-effects.php
+++ b/src/test/resources/fixtures/deadCode/side-effects.php
@@ -23,3 +23,10 @@ sideEffectPossible(1, $arg2);
 if (sideEffectPossible()) {
     <weak_warning descr="This call can be removed because it have no side-effect.">sideEffectPossible(sideEffectPossible());</weak_warning>
 }
+
+
+function sideEffectExternalResource(resource $resource) {
+}
+
+sideEffectExternalResource();
+sideEffectExternalResource($resource);

--- a/src/test/resources/fixtures/deadCode/side-effects.php
+++ b/src/test/resources/fixtures/deadCode/side-effects.php
@@ -82,7 +82,9 @@ class SideEffectNone_WithConstructor {
     public function __construct() {}
 }
 <weak_warning descr="This call can be removed because it have no side-effect.">new SideEffectNone_WithConstructor;</weak_warning>
+$sideEffectNone_WithoutConstructor = new SideEffectNone_WithConstructor;
 
 
 class SideEffectNone_WithoutConstructor {}
 <weak_warning descr="This call can be removed because it have no side-effect.">new SideEffectNone_WithoutConstructor;</weak_warning>
+$sideEffectNone_WithoutConstructor = new SideEffectNone_WithoutConstructor;

--- a/src/test/resources/fixtures/deadCode/side-effects.php
+++ b/src/test/resources/fixtures/deadCode/side-effects.php
@@ -30,3 +30,7 @@ function sideEffectExternalResource(resource $resource, &$possible = null) {
 
 sideEffectExternalResource();
 sideEffectExternalResource($resource);
+
+$shouldNotConsider = function () {
+};
+$shouldNotConsider();

--- a/src/test/resources/fixtures/deadCode/side-effects.php
+++ b/src/test/resources/fixtures/deadCode/side-effects.php
@@ -2,6 +2,7 @@
 
 sideEffectUnknow();
 
+
 function sideEffectNone($number = null) {
 }
 
@@ -10,12 +11,15 @@ function sideEffectNone($number = null) {
 
 if (sideEffectNone()) {
     <weak_warning descr="This call can be removed because it have no side-effect.">sideEffectNone(sideEffectNone());</weak_warning>
-    echo sideEffectNone();
-    return sideEffectNone();
 }
+
 
 function sideEffectPossible($arg1, &$arg2 = null) {
 }
 
 <weak_warning descr="This call can be removed because it have no side-effect.">sideEffectPossible(1);</weak_warning>
 sideEffectPossible(1, $arg2);
+
+if (sideEffectPossible()) {
+    <weak_warning descr="This call can be removed because it have no side-effect.">sideEffectPossible(sideEffectPossible());</weak_warning>
+}

--- a/src/test/resources/fixtures/deadCode/side-effects.php
+++ b/src/test/resources/fixtures/deadCode/side-effects.php
@@ -1,0 +1,7 @@
+<?php
+
+function sideEffectNone($number = null) {
+}
+
+<weak_warning descr="This call can be removed because it have no side-effect.">sideEffectNone();</weak_warning>
+<weak_warning descr="This call can be removed because it have no side-effect.">sideEffectNone(1);</weak_warning>

--- a/src/test/resources/fixtures/deadCode/side-effects.php
+++ b/src/test/resources/fixtures/deadCode/side-effects.php
@@ -50,6 +50,14 @@ function invalidMultilineAnnotation(){
 function invalidSinglelineAnnotation(){
 }
 
+<weak_warning descr="Multiple declarations of @side-effect is not allowed.">/**
+ * @side-effect none
+ * @side-effect external
+ */</weak_warning>
+function invalidMultipleAnnotations(){
+}
+
+
 /**
  * Emulating a PHP internal function.
  * @side-effect external

--- a/src/test/resources/fixtures/deadCode/side-effects.php
+++ b/src/test/resources/fixtures/deadCode/side-effects.php
@@ -35,7 +35,20 @@ $shouldNotConsider = function () {
 };
 $shouldNotConsider();
 
+<weak_warning descr="Unsupported value on property @side-effect.">/**
+ * @side-effect invalid
+ */</weak_warning>
+function invalidMultilineAnnotation(){
+}
 
+<weak_warning descr="Unsupported value on property @side-effect.">/** @side-effect invalid */</weak_warning>
+function invalidSinglelineAnnotation(){
+}
+
+/**
+ * Emulating a PHP internal function.
+ * @side-effect external
+ */
 function sleep() {
 }
 sleep();

--- a/src/test/resources/fixtures/deadCode/side-effects.php
+++ b/src/test/resources/fixtures/deadCode/side-effects.php
@@ -100,7 +100,7 @@ class SideEffectNone_WithConstructor {
 class SideEffectNone_WithoutConstructor {}
 <weak_warning descr="This call can be removed because it have no side-effect.">new SideEffectNone_WithoutConstructor;</weak_warning>
 <weak_warning descr="This call can be removed because it have no side-effect.">$sideEffectNone_WithoutConstructor = new SideEffectNone_WithoutConstructor;</weak_warning>
-return new SideEffectNone_WithoutConstructor;
+echo new SideEffectNone_WithoutConstructor;
 
 
 class SideEffect_FullExample {
@@ -108,5 +108,9 @@ class SideEffect_FullExample {
 }
 <weak_warning descr="This call can be removed because it have no side-effect.">$sideEffect_FullExample = new SideEffect_FullExample;</weak_warning>
 $sideEffect_FullExample->calculate();
+
+$sideEffect_FullExample_Echoed = new SideEffect_FullExample;
+echo $sideEffect_FullExample_Echoed->calculate();
+
 
 (new stdClass)->field = new SideEffect_FullExample();

--- a/src/test/resources/fixtures/deadCode/side-effects.php
+++ b/src/test/resources/fixtures/deadCode/side-effects.php
@@ -94,9 +94,16 @@ class SideEffectNone_WithConstructor {
     public function __construct() {}
 }
 <weak_warning descr="This call can be removed because it have no side-effect.">new SideEffectNone_WithConstructor;</weak_warning>
-$sideEffectNone_WithoutConstructor = new SideEffectNone_WithConstructor;
+<weak_warning descr="This call can be removed because it have no side-effect.">$sideEffectNone_WithoutConstructor = new SideEffectNone_WithConstructor;</weak_warning>
 
 
 class SideEffectNone_WithoutConstructor {}
 <weak_warning descr="This call can be removed because it have no side-effect.">new SideEffectNone_WithoutConstructor;</weak_warning>
-$sideEffectNone_WithoutConstructor = new SideEffectNone_WithoutConstructor;
+<weak_warning descr="This call can be removed because it have no side-effect.">$sideEffectNone_WithoutConstructor = new SideEffectNone_WithoutConstructor;</weak_warning>
+
+
+class SideEffect_FullExample {
+    public function calculate() { }
+}
+<weak_warning descr="This call can be removed because it have no side-effect.">$sideEffect_FullExample = new SideEffect_FullExample;</weak_warning>
+$sideEffect_FullExample->calculate();

--- a/src/test/resources/fixtures/deadCode/side-effects.php
+++ b/src/test/resources/fixtures/deadCode/side-effects.php
@@ -34,3 +34,8 @@ sideEffectExternalResource($resource);
 $shouldNotConsider = function () {
 };
 $shouldNotConsider();
+
+
+function sleep() {
+}
+sleep();

--- a/src/test/resources/fixtures/deadCode/side-effects.php
+++ b/src/test/resources/fixtures/deadCode/side-effects.php
@@ -7,3 +7,9 @@ function sideEffectNone($number = null) {
 
 <weak_warning descr="This call can be removed because it have no side-effect.">sideEffectNone();</weak_warning>
 <weak_warning descr="This call can be removed because it have no side-effect.">sideEffectNone(1);</weak_warning>
+
+function sideEffectPossible($arg1, &$arg2 = null) {
+}
+
+<weak_warning descr="This call can be removed because it have no side-effect.">sideEffectPossible(1);</weak_warning>
+sideEffectPossible(1, $arg2);

--- a/src/test/resources/fixtures/deadCode/side-effects.php
+++ b/src/test/resources/fixtures/deadCode/side-effects.php
@@ -76,3 +76,13 @@ function factorial(){
     return factorial();
 }
 <weak_warning descr="This call can be removed because it have no side-effect.">factorial();</weak_warning>
+
+
+class SideEffectNone_WithConstructor {
+    public function __construct() {}
+}
+<weak_warning descr="This call can be removed because it have no side-effect.">new SideEffectNone_WithConstructor;</weak_warning>
+
+
+class SideEffectNone_WithoutConstructor {}
+<weak_warning descr="This call can be removed because it have no side-effect.">new SideEffectNone_WithoutConstructor;</weak_warning>


### PR DESCRIPTION
I am implementing the feature request of #221.

**Working in progress: do not merge it yet**

- [x] Update `RULES.md`, `plugin.xml` and _inspection description_;
- [x] Identify no side-effect on know functions (with UT);
- [x] Identify and ignore unknow side-effect on not resolvable functions (with UT);
- [x] Identify possibles side-effects when exists refs on function parameters (with UT);
- [x] Identify external side-effects where function expects a `resource`-type parameter (with UT);
  - [ ] Identify which functions are no side-effect even in this cases (like `imagecolorat()`);
- [x] Identify side-effect on instanced variables, respecting which calls it does (with UT);
  - [ ] Think about how treat field references ($x->) and array assignments;
- [ ] Map all PHP functions that have external side-effects (_have some currently_);
- [ ] Think about how treats `call_func_array()` and `$callable()`, similars;
  - [ ] It includes things like `\ReflectionMethod::invokeArgs()`;
- [ ] Think about how treats _anonymous functions_;
- [ ] `class_exists()` is side-effect only if second parameter is `true`;
- [ ] `header()` is side-effect only more than one parameter is defined;
- [x] Implements supports to `@side-effect` annotation (with UT);
  - [x] Supports only `none`, `possible`, `unknow`, `internal`, `external` (with UT);
  - [x] Inspection for multiple definitions of this annotation (with UT);
  - [x] Inspection for invalid values for this annotation (with UT);
- [ ] Make it works with userland function and methods;
- [ ] _Think about this just now..._

Using [this](https://jsfiddle.net/fh68h40d/) to sort mapped things.

Reviews are welcome anytime.
