### PR TITLE
[#277] Optimizes the JComponent's creation on all inspection classes

### DIFF
--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/IsEmptyFunctionUsageInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/IsEmptyFunctionUsageInspector.java
@@ -32,9 +32,9 @@ import org.jetbrains.annotations.NotNull;
 
 public class IsEmptyFunctionUsageInspector extends BasePhpInspection {
     // Inspections options.
-    public boolean optionReportEmptyUsage       = false;
-    public boolean optionSuggestToUseCountCheck = false;
-    public boolean optionsToUseNullComparison   = true;
+    public boolean REPORT_EMPTY_USAGE             = false;
+    public boolean SUGGEST_TO_USE_COUNT_CHECK     = false;
+    public boolean SUGGEST_TO_USE_NULL_COMPARISON = true;
 
     private static final String messageDoNotUse          = "'empty(...)' counts too many values as empty, consider refactoring with type sensitive checks.";
     private static final String patternUseCount          = "You should probably use '%e%' instead.";
@@ -72,7 +72,7 @@ public class IsEmptyFunctionUsageInspector extends BasePhpInspection {
                     if (this.isArrayType(resolvedTypes)) {
                         resolvedTypes.clear();
 
-                        if (optionSuggestToUseCountCheck) {
+                        if (SUGGEST_TO_USE_COUNT_CHECK) {
                             final String replacement = "0 %o% count(%a%)"
                                 .replace("%a%", subject.getText())
                                 .replace("%o%", isInverted ? "!==": "===");
@@ -88,7 +88,7 @@ public class IsEmptyFunctionUsageInspector extends BasePhpInspection {
                     if (this.isNullableCoreType(resolvedTypes) || TypesSemanticsUtil.isNullableObjectInterface(resolvedTypes)) {
                         resolvedTypes.clear();
 
-                        if (optionsToUseNullComparison) {
+                        if (SUGGEST_TO_USE_NULL_COMPARISON) {
                             final String replacement = "null %o% %a%"
                                 .replace("%a%", subject.getText())
                                 .replace("%o%", isInverted ? "!==": "===");
@@ -103,7 +103,7 @@ public class IsEmptyFunctionUsageInspector extends BasePhpInspection {
                     resolvedTypes.clear();
                 }
 
-                if (optionReportEmptyUsage) {
+                if (REPORT_EMPTY_USAGE) {
                     holder.registerProblem(emptyExpression, messageDoNotUse, ProblemHighlightType.WEAK_WARNING);
                 }
             }
@@ -132,9 +132,9 @@ public class IsEmptyFunctionUsageInspector extends BasePhpInspection {
 
     public JComponent createOptionsPanel() {
         return OptionsComponent.create((component) -> {
-            component.createCheckbox("Report empty() usage", optionReportEmptyUsage, (isSelected) -> optionReportEmptyUsage = isSelected);
-            component.createCheckbox("Suggest to use count()-comparison", optionSuggestToUseCountCheck, (isSelected) -> optionSuggestToUseCountCheck = isSelected);
-            component.createCheckbox("Suggest to use null-comparison", optionsToUseNullComparison, (isSelected) -> optionsToUseNullComparison = isSelected);
+            component.createCheckbox("Report empty() usage", REPORT_EMPTY_USAGE, (isSelected) -> REPORT_EMPTY_USAGE = isSelected);
+            component.createCheckbox("Suggest to use count()-comparison", SUGGEST_TO_USE_COUNT_CHECK, (isSelected) -> SUGGEST_TO_USE_COUNT_CHECK = isSelected);
+            component.createCheckbox("Suggest to use null-comparison", SUGGEST_TO_USE_NULL_COMPARISON, (isSelected) -> SUGGEST_TO_USE_NULL_COMPARISON = isSelected);
         });
     }
 

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/PropertyInitializationFlawsInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/PropertyInitializationFlawsInspector.java
@@ -35,8 +35,8 @@ import org.jetbrains.annotations.NotNull;
 
 public class PropertyInitializationFlawsInspector extends BasePhpInspection {
     // Inspection options.
-    public boolean optionReportDefaultsFlaws = true;
-    public boolean optionReportInitFlaws     = true;
+    public boolean REPORT_DEFAULTS_FLAWS = true;
+    public boolean REPORT_INIT_FLAWS     = true;
 
     private static final String messageDefaultValue    = "Null assignment can be safely removed. Define null in annotations if it's important.";
     private static final String messageDefaultOverride = "The assignment can be safely removed as the constructor overrides it.";
@@ -53,7 +53,7 @@ public class PropertyInitializationFlawsInspector extends BasePhpInspection {
         return new BasePhpElementVisitor() {
             public void visitPhpField(Field field) {
                 /* configuration-based toggle */
-                if (!optionReportDefaultsFlaws) {
+                if (!REPORT_DEFAULTS_FLAWS) {
                     return;
                 }
 
@@ -80,7 +80,7 @@ public class PropertyInitializationFlawsInspector extends BasePhpInspection {
 
             public void visitPhpMethod(Method method) {
                 /* configuration-based toggle */
-                if (!optionReportInitFlaws) {
+                if (!REPORT_INIT_FLAWS) {
                     return;
                 }
 
@@ -153,7 +153,7 @@ public class PropertyInitializationFlawsInspector extends BasePhpInspection {
                             break;
                         }
 
-                        if (!isPropertyReused && optionReportDefaultsFlaws) {
+                        if (!isPropertyReused && REPORT_DEFAULTS_FLAWS) {
                             holder.registerProblem(fieldDefault, messageDefaultOverride, ProblemHighlightType.GENERIC_ERROR_OR_WARNING, new DropFieldDefaultValueFix());
                         }
                     }
@@ -165,8 +165,8 @@ public class PropertyInitializationFlawsInspector extends BasePhpInspection {
 
     public JComponent createOptionsPanel() {
         return OptionsComponent.create((component) -> {
-            component.createCheckbox("Check default values", optionReportDefaultsFlaws, (isSelected) -> optionReportDefaultsFlaws = isSelected);
-            component.createCheckbox("Check constructor", optionReportInitFlaws, (isSelected) -> optionReportInitFlaws = isSelected);
+            component.createCheckbox("Check default values", REPORT_DEFAULTS_FLAWS, (isSelected) -> REPORT_DEFAULTS_FLAWS = isSelected);
+            component.createCheckbox("Check constructor", REPORT_INIT_FLAWS, (isSelected) -> REPORT_INIT_FLAWS = isSelected);
         });
     }
 

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/RandomApiMigrationInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/RandomApiMigrationInspector.java
@@ -14,12 +14,13 @@ import com.jetbrains.php.config.PhpProjectConfigurationFacade;
 import com.jetbrains.php.lang.psi.elements.FunctionReference;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
-import net.miginfocom.swing.MigLayout;
-import org.jetbrains.annotations.NotNull;
+import com.kalessil.phpStorm.phpInspectionsEA.options.OptionsComponent;
 
 import javax.swing.*;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.jetbrains.annotations.NotNull;
 
 /*
  * This file is part of the Php Inspections (EA Extended) package.
@@ -31,8 +32,8 @@ import java.util.Map;
  */
 
 public class RandomApiMigrationInspector extends BasePhpInspection {
-    // configuration flags automatically saved by IDE
-    public boolean SUGGEST_USING_RANDOM_INT = true;
+    // Inspection options.
+    public boolean optionSuggestUsingRandomInt = true;
 
     private static final String messagePattern = "'%o%(...)' has recommended replacement '%n%(...)', consider migrating.";
 
@@ -55,7 +56,7 @@ public class RandomApiMigrationInspector extends BasePhpInspection {
     }
 
     private Map<String, String> getMapping(PhpLanguageLevel phpVersion) {
-        if (SUGGEST_USING_RANDOM_INT && phpVersion.hasFeature(PhpLanguageFeature.SCALAR_TYPE_HINTS)) {
+        if (optionSuggestUsingRandomInt && phpVersion.hasFeature(PhpLanguageFeature.SCALAR_TYPE_HINTS)) {
             return mappingEdge;
         }
 
@@ -95,26 +96,9 @@ public class RandomApiMigrationInspector extends BasePhpInspection {
     }
 
     public JComponent createOptionsPanel() {
-        return (new RandomApiMigrationInspector.OptionsPanel()).getComponent();
-    }
-
-    public class OptionsPanel {
-        final private JPanel optionsPanel;
-
-        final private JCheckBox suggestUsingRandomInt;
-
-        public OptionsPanel() {
-            optionsPanel = new JPanel();
-            optionsPanel.setLayout(new MigLayout());
-
-            suggestUsingRandomInt = new JCheckBox("Suggest using random_int", SUGGEST_USING_RANDOM_INT);
-            suggestUsingRandomInt.addChangeListener(e -> SUGGEST_USING_RANDOM_INT = suggestUsingRandomInt.isSelected());
-            optionsPanel.add(suggestUsingRandomInt, "wrap");
-        }
-
-        public JPanel getComponent() {
-            return optionsPanel;
-        }
+        return OptionsComponent.create((component) -> {
+            component.createCheckbox("Suggest using random_int", optionSuggestUsingRandomInt, (isSelected) -> optionSuggestUsingRandomInt = isSelected);
+        });
     }
 
     private static class TheLocalFix implements LocalQuickFix {

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/RandomApiMigrationInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/RandomApiMigrationInspector.java
@@ -33,7 +33,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class RandomApiMigrationInspector extends BasePhpInspection {
     // Inspection options.
-    public boolean optionSuggestUsingRandomInt = true;
+    public boolean SUGGEST_USING_RANDOM_INT = true;
 
     private static final String messagePattern = "'%o%(...)' has recommended replacement '%n%(...)', consider migrating.";
 
@@ -56,7 +56,7 @@ public class RandomApiMigrationInspector extends BasePhpInspection {
     }
 
     private Map<String, String> getMapping(PhpLanguageLevel phpVersion) {
-        if (optionSuggestUsingRandomInt && phpVersion.hasFeature(PhpLanguageFeature.SCALAR_TYPE_HINTS)) {
+        if (SUGGEST_USING_RANDOM_INT && phpVersion.hasFeature(PhpLanguageFeature.SCALAR_TYPE_HINTS)) {
             return mappingEdge;
         }
 
@@ -97,7 +97,7 @@ public class RandomApiMigrationInspector extends BasePhpInspection {
 
     public JComponent createOptionsPanel() {
         return OptionsComponent.create((component) -> {
-            component.createCheckbox("Suggest using random_int", optionSuggestUsingRandomInt, (isSelected) -> optionSuggestUsingRandomInt = isSelected);
+            component.createCheckbox("Suggest using random_int", SUGGEST_USING_RANDOM_INT, (isSelected) -> SUGGEST_USING_RANDOM_INT = isSelected);
         });
     }
 

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/UnSafeIsSetOverArrayInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/UnSafeIsSetOverArrayInspector.java
@@ -23,8 +23,8 @@ import org.jetbrains.annotations.NotNull;
 
 public class UnSafeIsSetOverArrayInspector extends BasePhpInspection {
     // Inspection options.
-    public boolean optionSuggestToUseArrayKeyExists = false;
-    public boolean optionSuggestToUseNullComparison = true;
+    public boolean SUGGEST_TO_USE_ARRAY_KEY_EXISTS = false;
+    public boolean SUGGEST_TO_USE_NULL_COMPARISON  = true;
 
     // static messages for triggered messages
     private static final String messageUseArrayKeyExists    = "'array_key_exists(...)' construction should be used for better data *structure* control.";
@@ -93,7 +93,7 @@ public class UnSafeIsSetOverArrayInspector extends BasePhpInspection {
                             }
                         }
 
-                        if (optionSuggestToUseNullComparison) {
+                        if (SUGGEST_TO_USE_NULL_COMPARISON) {
                             final String message = (issetInverted ? messageUseNullComparison : messageUseNotNullComparison)
                                     .replace("%s%", parameter.getText());
                             holder.registerProblem(parameter, message, ProblemHighlightType.WEAK_WARNING);
@@ -107,7 +107,7 @@ public class UnSafeIsSetOverArrayInspector extends BasePhpInspection {
                         continue;
                     }
 
-                    if (optionSuggestToUseArrayKeyExists && !isArrayAccess((ArrayAccessExpression) parameter)) {
+                    if (SUGGEST_TO_USE_ARRAY_KEY_EXISTS && !isArrayAccess((ArrayAccessExpression) parameter)) {
                         holder.registerProblem(parameter, messageUseArrayKeyExists, ProblemHighlightType.WEAK_WARNING);
                     }
                 }
@@ -177,8 +177,8 @@ public class UnSafeIsSetOverArrayInspector extends BasePhpInspection {
 
     public JComponent createOptionsPanel() {
         return OptionsComponent.create((component) -> {
-            component.createCheckbox("Suggest to use array_key_exists()", optionSuggestToUseArrayKeyExists, (isSelected) -> optionSuggestToUseArrayKeyExists = isSelected);
-            component.createCheckbox("Suggest to use null-comparison", optionSuggestToUseNullComparison, (isSelected) -> optionSuggestToUseNullComparison = isSelected);
+            component.createCheckbox("Suggest to use array_key_exists()", SUGGEST_TO_USE_ARRAY_KEY_EXISTS, (isSelected) -> SUGGEST_TO_USE_ARRAY_KEY_EXISTS = isSelected);
+            component.createCheckbox("Suggest to use null-comparison", SUGGEST_TO_USE_NULL_COMPARISON, (isSelected) -> SUGGEST_TO_USE_NULL_COMPARISON = isSelected);
         });
     }
-}
+    }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/UnSafeIsSetOverArrayInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/UnSafeIsSetOverArrayInspector.java
@@ -10,20 +10,21 @@ import com.jetbrains.php.lang.lexer.PhpTokenTypes;
 import com.jetbrains.php.lang.psi.elements.*;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
+import com.kalessil.phpStorm.phpInspectionsEA.options.OptionsComponent;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.ExpressionSemanticUtil;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.PhpLanguageUtil;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.TypeFromPlatformResolverUtil;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.Types;
-import net.miginfocom.swing.MigLayout;
-import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.util.HashSet;
 
+import org.jetbrains.annotations.NotNull;
+
 public class UnSafeIsSetOverArrayInspector extends BasePhpInspection {
-    // configuration flags automatically saved by IDE
-    public boolean SUGGEST_TO_USE_ARRAY_KEY_EXISTS = false;
-    public boolean SUGGEST_TO_USE_NULL_COMPARISON  = true;
+    // Inspection options.
+    public boolean optionSuggestToUseArrayKeyExists = false;
+    public boolean optionSuggestToUseNullComparison = true;
 
     // static messages for triggered messages
     private static final String messageUseArrayKeyExists    = "'array_key_exists(...)' construction should be used for better data *structure* control.";
@@ -92,7 +93,7 @@ public class UnSafeIsSetOverArrayInspector extends BasePhpInspection {
                             }
                         }
 
-                        if (SUGGEST_TO_USE_NULL_COMPARISON) {
+                        if (optionSuggestToUseNullComparison) {
                             final String message = (issetInverted ? messageUseNullComparison : messageUseNotNullComparison)
                                     .replace("%s%", parameter.getText());
                             holder.registerProblem(parameter, message, ProblemHighlightType.WEAK_WARNING);
@@ -106,7 +107,7 @@ public class UnSafeIsSetOverArrayInspector extends BasePhpInspection {
                         continue;
                     }
 
-                    if (SUGGEST_TO_USE_ARRAY_KEY_EXISTS && !isArrayAccess((ArrayAccessExpression) parameter)) {
+                    if (optionSuggestToUseArrayKeyExists && !isArrayAccess((ArrayAccessExpression) parameter)) {
                         holder.registerProblem(parameter, messageUseArrayKeyExists, ProblemHighlightType.WEAK_WARNING);
                     }
                 }
@@ -175,30 +176,9 @@ public class UnSafeIsSetOverArrayInspector extends BasePhpInspection {
     }
 
     public JComponent createOptionsPanel() {
-        return (new UnSafeIsSetOverArrayInspector.OptionsPanel()).getComponent();
-    }
-
-    public class OptionsPanel {
-        final private JPanel optionsPanel;
-
-        final private JCheckBox suggestToUseArrayKeyExists;
-        final private JCheckBox suggestToUseNullComparison;
-
-        public OptionsPanel() {
-            optionsPanel = new JPanel();
-            optionsPanel.setLayout(new MigLayout());
-
-            suggestToUseArrayKeyExists = new JCheckBox("Suggest to use array_key_exists()", SUGGEST_TO_USE_ARRAY_KEY_EXISTS);
-            suggestToUseArrayKeyExists.addChangeListener(e -> SUGGEST_TO_USE_ARRAY_KEY_EXISTS = suggestToUseArrayKeyExists.isSelected());
-            optionsPanel.add(suggestToUseArrayKeyExists, "wrap");
-
-            suggestToUseNullComparison = new JCheckBox("Suggest to use null-comparison", SUGGEST_TO_USE_NULL_COMPARISON);
-            suggestToUseNullComparison.addChangeListener(e -> SUGGEST_TO_USE_NULL_COMPARISON = suggestToUseNullComparison.isSelected());
-            optionsPanel.add(suggestToUseNullComparison, "wrap");
-        }
-
-        public JPanel getComponent() {
-            return optionsPanel;
-        }
+        return OptionsComponent.create((component) -> {
+            component.createCheckbox("Suggest to use array_key_exists()", optionSuggestToUseArrayKeyExists, (isSelected) -> optionSuggestToUseArrayKeyExists = isSelected);
+            component.createCheckbox("Suggest to use null-comparison", optionSuggestToUseNullComparison, (isSelected) -> optionSuggestToUseNullComparison = isSelected);
+        });
     }
 }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/debug/ForgottenDebugOutputInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/debug/ForgottenDebugOutputInspector.java
@@ -11,16 +11,16 @@ import com.intellij.util.xmlb.XmlSerializer;
 import com.jetbrains.php.lang.lexer.PhpTokenTypes;
 import com.jetbrains.php.lang.psi.elements.*;
 import com.jetbrains.php.lang.psi.elements.impl.StatementImpl;
-import com.kalessil.phpStorm.phpInspectionsEA.gui.PrettyListControl;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
+import com.kalessil.phpStorm.phpInspectionsEA.options.OptionsComponent;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.OpenapiTypesUtil;
-import net.miginfocom.swing.MigLayout;
 import org.jdom.Element;
-import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.util.*;
+
+import org.jetbrains.annotations.NotNull;
 
 /*
  * This file is part of the Php Inspections (EA Extended) package.
@@ -32,8 +32,9 @@ import java.util.*;
  */
 
 public class ForgottenDebugOutputInspector extends BasePhpInspection {
-    // custom configuration, automatically saved between restarts so keep out of changing modifiers
-    final public List<String> configuration       = new ArrayList<>();
+    // Inspection options.
+    private final List<String> optionCustomDebugMethods = new ArrayList<>();
+
     public boolean defaultsTransferredToUserSpace = false;
 
     final private Set<String> customFunctions                     = new HashSet<>();
@@ -52,7 +53,7 @@ public class ForgottenDebugOutputInspector extends BasePhpInspection {
     }
 
     public void registerCustomDebugMethod(@NotNull String fqn) {
-        this.configuration.add(fqn);
+        this.optionCustomDebugMethods.add(fqn);
         this.recompileConfiguration();
     }
 
@@ -75,17 +76,17 @@ public class ForgottenDebugOutputInspector extends BasePhpInspection {
             migrated.add("\\Zend\\Di\\Display\\Console::export");
             migrated.add("error_log");
             migrated.add("phpinfo");
-            migrated.addAll(this.configuration);
+            migrated.addAll(this.optionCustomDebugMethods);
 
             /* migrate the list */
-            this.configuration.clear();
-            this.configuration.addAll(migrated);
+            this.optionCustomDebugMethods.clear();
+            this.optionCustomDebugMethods.addAll(migrated);
             this.defaultsTransferredToUserSpace = true;
 
             /* cleanup */
             migrated.clear();
         }
-        customDebugFQNs.addAll(this.configuration);
+        customDebugFQNs.addAll(this.optionCustomDebugMethods);
 
         /* parse what was provided FQNs */
         for (String stringDescriptor : customDebugFQNs) {
@@ -193,27 +194,8 @@ public class ForgottenDebugOutputInspector extends BasePhpInspection {
     }
 
     public JComponent createOptionsPanel() {
-        return (new ForgottenDebugOutputInspector.OptionsPanel()).getComponent();
-    }
-
-    private class OptionsPanel {
-        final private JPanel optionsPanel;
-
-        private OptionsPanel() {
-            optionsPanel = new JPanel();
-            optionsPanel.setLayout(new MigLayout());
-
-            optionsPanel.add(new JLabel("Custom debug methods:"), "wrap");
-            optionsPanel.add((new PrettyListControl(configuration) {
-                protected void fireContentsChanged() {
-                    recompileConfiguration();
-                    super.fireContentsChanged();
-                }
-            }).getComponent(), "pushx, growx");
-        }
-
-        private JPanel getComponent() {
-            return optionsPanel;
-        }
+        return OptionsComponent.create((component) -> {
+            component.createList("Custom debug methods:", optionCustomDebugMethods, this::recompileConfiguration);
+        });
     }
 }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/debug/ForgottenDebugOutputInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/debug/ForgottenDebugOutputInspector.java
@@ -33,7 +33,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class ForgottenDebugOutputInspector extends BasePhpInspection {
     // Inspection options.
-    private final List<String> optionCustomDebugMethods = new ArrayList<>();
+    private final List<String> configuration = new ArrayList<>();
 
     public boolean defaultsTransferredToUserSpace = false;
 
@@ -53,7 +53,7 @@ public class ForgottenDebugOutputInspector extends BasePhpInspection {
     }
 
     public void registerCustomDebugMethod(@NotNull String fqn) {
-        this.optionCustomDebugMethods.add(fqn);
+        this.configuration.add(fqn);
         this.recompileConfiguration();
     }
 
@@ -76,17 +76,17 @@ public class ForgottenDebugOutputInspector extends BasePhpInspection {
             migrated.add("\\Zend\\Di\\Display\\Console::export");
             migrated.add("error_log");
             migrated.add("phpinfo");
-            migrated.addAll(this.optionCustomDebugMethods);
+            migrated.addAll(this.configuration);
 
             /* migrate the list */
-            this.optionCustomDebugMethods.clear();
-            this.optionCustomDebugMethods.addAll(migrated);
+            this.configuration.clear();
+            this.configuration.addAll(migrated);
             this.defaultsTransferredToUserSpace = true;
 
             /* cleanup */
             migrated.clear();
         }
-        customDebugFQNs.addAll(this.optionCustomDebugMethods);
+        customDebugFQNs.addAll(this.configuration);
 
         /* parse what was provided FQNs */
         for (String stringDescriptor : customDebugFQNs) {
@@ -195,7 +195,7 @@ public class ForgottenDebugOutputInspector extends BasePhpInspection {
 
     public JComponent createOptionsPanel() {
         return OptionsComponent.create((component) -> {
-            component.createList("Custom debug methods:", optionCustomDebugMethods, this::recompileConfiguration);
+            component.createList("Custom debug methods:", configuration, this::recompileConfiguration);
         });
     }
 }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/ComparisonOperandsOrderInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/ComparisonOperandsOrderInspector.java
@@ -34,8 +34,8 @@ import org.jetbrains.annotations.NotNull;
 
 public class ComparisonOperandsOrderInspector extends BasePhpInspection {
     // Inspection options.
-    public boolean optionPreferYodaStyle    = false;
-    public boolean optionPreferRegularStyle = false;
+    public boolean PREFER_YODA_STYLE    = false;
+    public boolean PREFER_REGULAR_STYLE = false;
 
     final static private String messageUseYoda    = "Yoda conditions style should be used instead";
     final static private String messageUseRegular = "Regular conditions style should be used instead";
@@ -58,7 +58,7 @@ public class ComparisonOperandsOrderInspector extends BasePhpInspection {
     public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder holder, boolean isOnTheFly) {
         return new BasePhpElementVisitor() {
             public void visitPhpBinaryExpression(BinaryExpression expression) {
-                if (!optionPreferYodaStyle && !optionPreferRegularStyle) {
+                if (!PREFER_YODA_STYLE && !PREFER_REGULAR_STYLE) {
                     return;
                 }
 
@@ -83,11 +83,11 @@ public class ComparisonOperandsOrderInspector extends BasePhpInspection {
                     return;
                 }
 
-                if (optionPreferYodaStyle && isRightConstant) {
+                if (PREFER_YODA_STYLE && isRightConstant) {
                     holder.registerProblem(expression, messageUseYoda, ProblemHighlightType.WEAK_WARNING, new TheLocalFix());
                     return;
                 }
-                if (optionPreferRegularStyle && isLeftConstant) {
+                if (PREFER_REGULAR_STYLE && isLeftConstant) {
                     holder.registerProblem(expression, messageUseRegular, ProblemHighlightType.WEAK_WARNING, new TheLocalFix());
                 }
             }
@@ -97,8 +97,8 @@ public class ComparisonOperandsOrderInspector extends BasePhpInspection {
     public JComponent createOptionsPanel() {
         return OptionsComponent.create((component) -> {
             component.createRadio((radioComponent) -> {
-                radioComponent.createOption("Prefer yoda style", optionPreferYodaStyle, (isSelected) -> optionPreferYodaStyle = isSelected);
-                radioComponent.createOption("Prefer regular style", optionPreferRegularStyle, (isSelected) -> optionPreferRegularStyle = isSelected);
+                radioComponent.createOption("Prefer yoda style", PREFER_YODA_STYLE, (isSelected) -> PREFER_YODA_STYLE = isSelected);
+                radioComponent.createOption("Prefer regular style", PREFER_REGULAR_STYLE, (isSelected) -> PREFER_REGULAR_STYLE = isSelected);
             });
         });
     }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/ComparisonOperandsOrderInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/ComparisonOperandsOrderInspector.java
@@ -15,12 +15,13 @@ import com.jetbrains.php.lang.psi.elements.ConstantReference;
 import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
-import net.miginfocom.swing.MigLayout;
-import org.jetbrains.annotations.NotNull;
+import com.kalessil.phpStorm.phpInspectionsEA.options.OptionsComponent;
 
 import javax.swing.*;
 import java.util.HashSet;
 import java.util.Set;
+
+import org.jetbrains.annotations.NotNull;
 
 /*
  * This file is part of the Php Inspections (EA Extended) package.
@@ -32,10 +33,9 @@ import java.util.Set;
  */
 
 public class ComparisonOperandsOrderInspector extends BasePhpInspection {
-    // configuration flags automatically saved by IDE
-    public boolean CONFIGURED           = false;
-    public boolean PREFER_YODA_STYLE    = false;
-    public boolean PREFER_REGULAR_STYLE = false;
+    // Inspection options.
+    public boolean optionPreferYodaStyle    = false;
+    public boolean optionPreferRegularStyle = false;
 
     final static private String messageUseYoda    = "Yoda conditions style should be used instead";
     final static private String messageUseRegular = "Regular conditions style should be used instead";
@@ -58,10 +58,14 @@ public class ComparisonOperandsOrderInspector extends BasePhpInspection {
     public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder holder, boolean isOnTheFly) {
         return new BasePhpElementVisitor() {
             public void visitPhpBinaryExpression(BinaryExpression expression) {
+                if (!optionPreferYodaStyle && !optionPreferRegularStyle) {
+                    return;
+                }
+
                 /* verify general structure */
-                final IElementType operator = CONFIGURED ? expression.getOperationType() : null;
-                final PsiElement left       = CONFIGURED ? expression.getLeftOperand() : null;
-                final PsiElement right      = CONFIGURED ? expression.getRightOperand() : null;
+                final IElementType operator = expression.getOperationType();
+                final PsiElement   left     = expression.getLeftOperand();
+                final PsiElement   right    = expression.getRightOperand();
                 if (null == operator || null == left || null == right || !operations.contains(operator)) {
                     return;
                 }
@@ -79,11 +83,11 @@ public class ComparisonOperandsOrderInspector extends BasePhpInspection {
                     return;
                 }
 
-                if (PREFER_YODA_STYLE && isRightConstant) {
+                if (optionPreferYodaStyle && isRightConstant) {
                     holder.registerProblem(expression, messageUseYoda, ProblemHighlightType.WEAK_WARNING, new TheLocalFix());
                     return;
                 }
-                if (PREFER_REGULAR_STYLE && isLeftConstant) {
+                if (optionPreferRegularStyle && isLeftConstant) {
                     holder.registerProblem(expression, messageUseRegular, ProblemHighlightType.WEAK_WARNING, new TheLocalFix());
                 }
             }
@@ -91,48 +95,12 @@ public class ComparisonOperandsOrderInspector extends BasePhpInspection {
     }
 
     public JComponent createOptionsPanel() {
-        return (new ComparisonOperandsOrderInspector.OptionsPanel()).getComponent();
-    }
-
-    private class OptionsPanel {
-        final private JPanel optionsPanel;
-
-        final private JCheckBox preferYodaStyle;
-        final private JCheckBox preferRegularStyle;
-
-        public OptionsPanel() {
-            optionsPanel = new JPanel();
-            optionsPanel.setLayout(new MigLayout());
-
-            preferYodaStyle    = new JCheckBox("Prefer yoda style", PREFER_YODA_STYLE);
-            preferRegularStyle = new JCheckBox("Prefer regular style", PREFER_REGULAR_STYLE);
-
-            preferYodaStyle.addChangeListener(e -> {
-                PREFER_YODA_STYLE = preferYodaStyle.isSelected();
-                if (PREFER_YODA_STYLE) {
-                    preferRegularStyle.setSelected(false);
-                    PREFER_REGULAR_STYLE = false;
-                }
-
-                CONFIGURED = PREFER_YODA_STYLE || PREFER_REGULAR_STYLE;
+        return OptionsComponent.create((component) -> {
+            component.createRadio((radioComponent) -> {
+                radioComponent.createOption("Prefer yoda style", optionPreferYodaStyle, (isSelected) -> optionPreferYodaStyle = isSelected);
+                radioComponent.createOption("Prefer regular style", optionPreferRegularStyle, (isSelected) -> optionPreferRegularStyle = isSelected);
             });
-            optionsPanel.add(preferYodaStyle, "wrap");
-
-            preferRegularStyle.addChangeListener(e -> {
-                PREFER_REGULAR_STYLE = preferRegularStyle.isSelected();
-                if (PREFER_REGULAR_STYLE) {
-                    preferYodaStyle.setSelected(false);
-                    PREFER_YODA_STYLE = false;
-                }
-
-                CONFIGURED = PREFER_YODA_STYLE || PREFER_REGULAR_STYLE;
-            });
-            optionsPanel.add(preferRegularStyle, "wrap");
-        }
-
-        JPanel getComponent() {
-            return optionsPanel;
-        }
+        });
     }
 
     private static class TheLocalFix implements LocalQuickFix {

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/DisallowWritingIntoStaticPropertiesInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/DisallowWritingIntoStaticPropertiesInspector.java
@@ -17,7 +17,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class DisallowWritingIntoStaticPropertiesInspector extends BasePhpInspection {
     // Inspection options.
-    public boolean optionAllowWriteFromSourceClass = true;
+    public boolean ALLOW_WRITE_FROM_SOURCE_CLASS = true;
 
     private static final String messageDisallowExternalWrites = "Static property should be modified only inside the source class";
     private static final String messageDisallowAnyWrites = "Static property should not be modified";
@@ -46,7 +46,7 @@ public class DisallowWritingIntoStaticPropertiesInspector extends BasePhpInspect
                     return;
                 }
 
-                if (!optionAllowWriteFromSourceClass) {
+                if (!ALLOW_WRITE_FROM_SOURCE_CLASS) {
                     holder.registerProblem(assignmentExpression, messageDisallowAnyWrites, ProblemHighlightType.GENERIC_ERROR_OR_WARNING);
                     return;
                 }
@@ -103,7 +103,7 @@ public class DisallowWritingIntoStaticPropertiesInspector extends BasePhpInspect
 
     public JComponent createOptionsPanel() {
         return OptionsComponent.create((component) -> {
-            component.createCheckbox("Allow write from the source class", optionAllowWriteFromSourceClass, (isSelected) -> optionAllowWriteFromSourceClass = isSelected);
+            component.createCheckbox("Allow write from the source class", ALLOW_WRITE_FROM_SOURCE_CLASS, (isSelected) -> ALLOW_WRITE_FROM_SOURCE_CLASS = isSelected);
         });
     }
 }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/DisallowWritingIntoStaticPropertiesInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/DisallowWritingIntoStaticPropertiesInspector.java
@@ -7,16 +7,17 @@ import com.intellij.psi.PsiElementVisitor;
 import com.jetbrains.php.lang.psi.elements.*;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
+import com.kalessil.phpStorm.phpInspectionsEA.options.OptionsComponent;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.ExpressionSemanticUtil;
-import net.miginfocom.swing.MigLayout;
-import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 
+import org.jetbrains.annotations.NotNull;
+
 
 public class DisallowWritingIntoStaticPropertiesInspector extends BasePhpInspection {
-
-    public boolean ALLOW_WRITE_FROM_SOURCE_CLASS = true;
+    // Inspection options.
+    public boolean optionAllowWriteFromSourceClass = true;
 
     private static final String messageDisallowExternalWrites = "Static property should be modified only inside the source class";
     private static final String messageDisallowAnyWrites = "Static property should not be modified";
@@ -45,7 +46,7 @@ public class DisallowWritingIntoStaticPropertiesInspector extends BasePhpInspect
                     return;
                 }
 
-                if (!ALLOW_WRITE_FROM_SOURCE_CLASS) {
+                if (!optionAllowWriteFromSourceClass) {
                     holder.registerProblem(assignmentExpression, messageDisallowAnyWrites, ProblemHighlightType.GENERIC_ERROR_OR_WARNING);
                     return;
                 }
@@ -101,30 +102,8 @@ public class DisallowWritingIntoStaticPropertiesInspector extends BasePhpInspect
     }
 
     public JComponent createOptionsPanel() {
-        return (new OptionsPanel()).getComponent();
+        return OptionsComponent.create((component) -> {
+            component.createCheckbox("Allow write from the source class", optionAllowWriteFromSourceClass, (isSelected) -> optionAllowWriteFromSourceClass = isSelected);
+        });
     }
-
-    private class OptionsPanel {
-        final private JPanel optionsPanel;
-
-        final private JCheckBox allowWriteFromSourceClassC;
-
-
-        public OptionsPanel() {
-            optionsPanel = new JPanel();
-            optionsPanel.setLayout(new MigLayout());
-
-            allowWriteFromSourceClassC = new JCheckBox("Allow write from the source class", ALLOW_WRITE_FROM_SOURCE_CLASS);
-
-
-            allowWriteFromSourceClassC.addChangeListener(e -> ALLOW_WRITE_FROM_SOURCE_CLASS = allowWriteFromSourceClassC.isSelected());
-            optionsPanel.add(allowWriteFromSourceClassC, "wrap");
-
-        }
-
-        JPanel getComponent() {
-            return optionsPanel;
-        }
-    }
-
 }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/UsageOfSilenceOperatorInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/UsageOfSilenceOperatorInspector.java
@@ -12,15 +12,16 @@ import com.jetbrains.php.lang.lexer.PhpTokenTypes;
 import com.jetbrains.php.lang.psi.elements.*;
 import com.jetbrains.php.lang.psi.visitors.PhpElementVisitor;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
+import com.kalessil.phpStorm.phpInspectionsEA.options.OptionsComponent;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.ExpressionSemanticUtil;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.OpenapiTypesUtil;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.PhpLanguageUtil;
-import net.miginfocom.swing.MigLayout;
-import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.util.Arrays;
 import java.util.List;
+
+import org.jetbrains.annotations.NotNull;
 
 /*
  * This file is part of the Php Inspections (EA Extended) package.
@@ -33,8 +34,8 @@ import java.util.List;
  */
 
 public class UsageOfSilenceOperatorInspector extends BasePhpInspection {
-    // configuration flags automatically saved by IDE
-    public boolean RESPECT_CONTEXT = true;
+    // Inspection options.
+    public boolean optionRespectContext = false;
 
     private static final String message = "Try to avoid using the @, as it hides problems and complicates troubleshooting.";
 
@@ -82,7 +83,7 @@ public class UsageOfSilenceOperatorInspector extends BasePhpInspection {
 
                 /* valid contexts: `... = @...`, ` return @... ` */
                 PsiElement parent = unaryExpression.getParent();
-                if (RESPECT_CONTEXT) {
+                if (optionRespectContext) {
                     if (parent instanceof TernaryExpression) {
                         parent = parent.getParent();
                     }
@@ -108,7 +109,7 @@ public class UsageOfSilenceOperatorInspector extends BasePhpInspection {
                     return;
                 }
 
-                if (RESPECT_CONTEXT) {
+                if (optionRespectContext) {
                     /* valid context: ` false === @... `, ` false !== @... ` */
                     if (parent instanceof BinaryExpression) {
                         final BinaryExpression parentExpression = (BinaryExpression) parent;
@@ -135,27 +136,9 @@ public class UsageOfSilenceOperatorInspector extends BasePhpInspection {
     }
 
     public JComponent createOptionsPanel() {
-        return (new UsageOfSilenceOperatorInspector.OptionsPanel()).getComponent();
-    }
-
-    private class OptionsPanel {
-        final private JPanel optionsPanel;
-
-        final private JCheckBox contentAware;
-
-        public OptionsPanel() {
-            optionsPanel = new JPanel();
-            optionsPanel.setLayout(new MigLayout());
-
-            contentAware = new JCheckBox("Content aware reporting", RESPECT_CONTEXT);
-
-            contentAware.addChangeListener(e -> RESPECT_CONTEXT = contentAware.isSelected());
-            optionsPanel.add(contentAware, "wrap");
-        }
-
-        JPanel getComponent() {
-            return optionsPanel;
-        }
+        return OptionsComponent.create((component) -> {
+            component.createCheckbox("Content aware reporting", optionRespectContext, (isSelected) -> optionRespectContext = isSelected);
+        });
     }
 
     private static class TheLocalFix implements LocalQuickFix {

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/UsageOfSilenceOperatorInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/UsageOfSilenceOperatorInspector.java
@@ -35,7 +35,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class UsageOfSilenceOperatorInspector extends BasePhpInspection {
     // Inspection options.
-    public boolean optionRespectContext = false;
+    public boolean RESPECT_CONTEXT = false;
 
     private static final String message = "Try to avoid using the @, as it hides problems and complicates troubleshooting.";
 
@@ -83,7 +83,7 @@ public class UsageOfSilenceOperatorInspector extends BasePhpInspection {
 
                 /* valid contexts: `... = @...`, ` return @... ` */
                 PsiElement parent = unaryExpression.getParent();
-                if (optionRespectContext) {
+                if (RESPECT_CONTEXT) {
                     if (parent instanceof TernaryExpression) {
                         parent = parent.getParent();
                     }
@@ -109,7 +109,7 @@ public class UsageOfSilenceOperatorInspector extends BasePhpInspection {
                     return;
                 }
 
-                if (optionRespectContext) {
+                if (RESPECT_CONTEXT) {
                     /* valid context: ` false === @... `, ` false !== @... ` */
                     if (parent instanceof BinaryExpression) {
                         final BinaryExpression parentExpression = (BinaryExpression) parent;
@@ -137,7 +137,7 @@ public class UsageOfSilenceOperatorInspector extends BasePhpInspection {
 
     public JComponent createOptionsPanel() {
         return OptionsComponent.create((component) -> {
-            component.createCheckbox("Content aware reporting", optionRespectContext, (isSelected) -> optionRespectContext = isSelected);
+            component.createCheckbox("Content aware reporting", RESPECT_CONTEXT, (isSelected) -> RESPECT_CONTEXT = isSelected);
         });
     }
 

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/exceptions/ExceptionsAnnotatingAndHandlingInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/exceptions/ExceptionsAnnotatingAndHandlingInspector.java
@@ -20,22 +20,21 @@ import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.jetbrains.php.lang.psi.elements.Try;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
+import com.kalessil.phpStorm.phpInspectionsEA.options.OptionsComponent;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.FileSystemUtil;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.NamedElementUtil;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.hierarhy.InterfacesExtractUtil;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.phpDoc.ThrowsResolveUtil;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.phpExceptions.CollectPossibleThrowsUtil;
-import net.miginfocom.swing.MigLayout;
-import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.util.*;
 
+import org.jetbrains.annotations.NotNull;
+
 public class ExceptionsAnnotatingAndHandlingInspector extends BasePhpInspection {
-    /* TODO: add settings for FQNs which doesn't need to be reported */
-    // configuration flags automatically saved by IDE
-    @SuppressWarnings("WeakerAccess")
-    public boolean REPORT_NON_THROWN_EXCEPTIONS = false;
+    // Inspection options.
+    private boolean optionReportNonThrownExceptions = false;
 
     private static final String messagePattern           = "Throws a non-annotated/unhandled exception: '%c%'.";
     private static final String messagePatternUnthrown   = "Following exceptions annotated, but not thrown: '%c%'.";
@@ -126,7 +125,7 @@ public class ExceptionsAnnotatingAndHandlingInspector extends BasePhpInspection 
 
 
                 /* do reporting now: exceptions annotated, but not thrown */
-                if (REPORT_NON_THROWN_EXCEPTIONS && annotatedButNotThrownExceptions.size() > 0) {
+                if (optionReportNonThrownExceptions && annotatedButNotThrownExceptions.size() > 0) {
                     List<String> toReport = new ArrayList<>();
                     for (PhpClass notThrown : annotatedButNotThrownExceptions) {
                         toReport.add(notThrown.getFQN());
@@ -282,26 +281,8 @@ public class ExceptionsAnnotatingAndHandlingInspector extends BasePhpInspection 
     }
 
     public JComponent createOptionsPanel() {
-        return (new ExceptionsAnnotatingAndHandlingInspector.OptionsPanel()).getComponent();
+        return OptionsComponent.create((component) -> {
+            component.createCheckbox("Report non-thrown exceptions", optionReportNonThrownExceptions, (isSelected) -> optionReportNonThrownExceptions = isSelected);
+        });
     }
-
-    public class OptionsPanel {
-        final private JPanel optionsPanel;
-
-        final private JCheckBox importClassesAutomatically;
-
-        public OptionsPanel() {
-            optionsPanel = new JPanel();
-            optionsPanel.setLayout(new MigLayout());
-
-            importClassesAutomatically = new JCheckBox("Report non-thrown exceptions", REPORT_NON_THROWN_EXCEPTIONS);
-            importClassesAutomatically.addChangeListener(e -> REPORT_NON_THROWN_EXCEPTIONS = importClassesAutomatically.isSelected());
-            optionsPanel.add(importClassesAutomatically, "wrap");
-        }
-
-        public JPanel getComponent() {
-            return optionsPanel;
-        }
-    }
-
 }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/exceptions/ExceptionsAnnotatingAndHandlingInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/exceptions/ExceptionsAnnotatingAndHandlingInspector.java
@@ -34,7 +34,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class ExceptionsAnnotatingAndHandlingInspector extends BasePhpInspection {
     // Inspection options.
-    private boolean optionReportNonThrownExceptions = false;
+    private boolean REPORT_NON_THROWN_EXCEPTIONS = false;
 
     private static final String messagePattern           = "Throws a non-annotated/unhandled exception: '%c%'.";
     private static final String messagePatternUnthrown   = "Following exceptions annotated, but not thrown: '%c%'.";
@@ -125,7 +125,7 @@ public class ExceptionsAnnotatingAndHandlingInspector extends BasePhpInspection 
 
 
                 /* do reporting now: exceptions annotated, but not thrown */
-                if (optionReportNonThrownExceptions && annotatedButNotThrownExceptions.size() > 0) {
+                if (REPORT_NON_THROWN_EXCEPTIONS && annotatedButNotThrownExceptions.size() > 0) {
                     List<String> toReport = new ArrayList<>();
                     for (PhpClass notThrown : annotatedButNotThrownExceptions) {
                         toReport.add(notThrown.getFQN());
@@ -282,7 +282,7 @@ public class ExceptionsAnnotatingAndHandlingInspector extends BasePhpInspection 
 
     public JComponent createOptionsPanel() {
         return OptionsComponent.create((component) -> {
-            component.createCheckbox("Report non-thrown exceptions", optionReportNonThrownExceptions, (isSelected) -> optionReportNonThrownExceptions = isSelected);
+            component.createCheckbox("Report non-thrown exceptions", REPORT_NON_THROWN_EXCEPTIONS, (isSelected) -> REPORT_NON_THROWN_EXCEPTIONS = isSelected);
         });
     }
 }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/forEach/AlterInForeachInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/forEach/AlterInForeachInspector.java
@@ -13,14 +13,15 @@ import com.jetbrains.php.lang.psi.PhpFile;
 import com.jetbrains.php.lang.psi.elements.*;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
-import net.miginfocom.swing.MigLayout;
-import org.jetbrains.annotations.NotNull;
+import com.kalessil.phpStorm.phpInspectionsEA.options.OptionsComponent;
 
 import javax.swing.*;
 
+import org.jetbrains.annotations.NotNull;
+
 public class AlterInForeachInspector extends BasePhpInspection {
-    // configuration flags automatically saved by IDE
-    public boolean SUGGEST_USING_VALUE_BY_REF = false;
+    // Inspection options.
+    public boolean optionSuggestUsingValueByRef = false;
 
     private static final String patternSuggestReference = "Can be refactored as '$%c% = ...' if $%v% is defined as a reference (ensure that array supplied). Suppress if causes memory mismatches.";
     private static final String messageMissingUnset     = "This variable must be unset just after foreach to prevent possible side-effects.";
@@ -151,7 +152,7 @@ public class AlterInForeachInspector extends BasePhpInspection {
             }
 
             public void visitPhpAssignmentExpression(AssignmentExpression assignmentExpression) {
-                if (!SUGGEST_USING_VALUE_BY_REF /*|| ... PHP7 ...*/) {
+                if (!optionSuggestUsingValueByRef /*|| ... PHP7 ...*/) {
                     return;
                 }
 
@@ -214,25 +215,8 @@ public class AlterInForeachInspector extends BasePhpInspection {
     }
 
     public JComponent createOptionsPanel() {
-        return (new AlterInForeachInspector.OptionsPanel()).getComponent();
-    }
-
-    private class OptionsPanel {
-        final private JPanel optionsPanel;
-
-        final private JCheckBox suggestUsingValueByRef;
-
-        public OptionsPanel() {
-            optionsPanel = new JPanel();
-            optionsPanel.setLayout(new MigLayout());
-
-            suggestUsingValueByRef = new JCheckBox("Suggest using value by reference", SUGGEST_USING_VALUE_BY_REF);
-            suggestUsingValueByRef.addChangeListener(e -> SUGGEST_USING_VALUE_BY_REF = suggestUsingValueByRef.isSelected());
-            optionsPanel.add(suggestUsingValueByRef, "wrap");
-        }
-
-        JPanel getComponent() {
-            return optionsPanel;
-        }
+        return OptionsComponent.create((component) -> {
+            component.createCheckbox("Suggest using value by reference", optionSuggestUsingValueByRef, (isSelected) -> optionSuggestUsingValueByRef = isSelected);
+        });
     }
 }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/forEach/AlterInForeachInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/forEach/AlterInForeachInspector.java
@@ -21,7 +21,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class AlterInForeachInspector extends BasePhpInspection {
     // Inspection options.
-    public boolean optionSuggestUsingValueByRef = false;
+    public boolean SUGGEST_USING_VALUE_BY_REF = false;
 
     private static final String patternSuggestReference = "Can be refactored as '$%c% = ...' if $%v% is defined as a reference (ensure that array supplied). Suppress if causes memory mismatches.";
     private static final String messageMissingUnset     = "This variable must be unset just after foreach to prevent possible side-effects.";
@@ -152,7 +152,7 @@ public class AlterInForeachInspector extends BasePhpInspection {
             }
 
             public void visitPhpAssignmentExpression(AssignmentExpression assignmentExpression) {
-                if (!optionSuggestUsingValueByRef /*|| ... PHP7 ...*/) {
+                if (!SUGGEST_USING_VALUE_BY_REF /*|| ... PHP7 ...*/) {
                     return;
                 }
 
@@ -216,7 +216,7 @@ public class AlterInForeachInspector extends BasePhpInspection {
 
     public JComponent createOptionsPanel() {
         return OptionsComponent.create((component) -> {
-            component.createCheckbox("Suggest using value by reference", optionSuggestUsingValueByRef, (isSelected) -> optionSuggestUsingValueByRef = isSelected);
+            component.createCheckbox("Suggest using value by reference", SUGGEST_USING_VALUE_BY_REF, (isSelected) -> SUGGEST_USING_VALUE_BY_REF = isSelected);
         });
     }
 }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/forEach/DisconnectedForeachInstructionInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/forEach/DisconnectedForeachInstructionInspector.java
@@ -34,7 +34,7 @@ import org.jetbrains.annotations.Nullable;
 
 public class DisconnectedForeachInstructionInspector extends BasePhpInspection {
     // Inspection options.
-    public boolean optionSuggestUsingClone = false;
+    public boolean SUGGEST_USING_CLONE = false;
 
     private static final String messageDisconnected = "This statement seems to be disconnected from its parent foreach.";
     private static final String messageUseClone     = "Objects should be created outside of a loop and cloned instead.";
@@ -135,7 +135,7 @@ public class DisconnectedForeachInstructionInspector extends BasePhpInspection {
                                     }
                                 }
 
-                                if (optionSuggestUsingClone && (ExpressionType.DOM_ELEMENT_CREATE == target || ExpressionType.NEW == target)) {
+                                if (SUGGEST_USING_CLONE && (ExpressionType.DOM_ELEMENT_CREATE == target || ExpressionType.NEW == target)) {
                                     holder.registerProblem(oneInstruction, messageUseClone, ProblemHighlightType.GENERIC_ERROR_OR_WARNING);
                                 }
                             }
@@ -315,7 +315,7 @@ public class DisconnectedForeachInstructionInspector extends BasePhpInspection {
 
     public JComponent createOptionsPanel() {
         return OptionsComponent.create((component) -> {
-            component.createCheckbox("Suggest using clone", optionSuggestUsingClone, (isSelected) -> optionSuggestUsingClone = isSelected);
+            component.createCheckbox("Suggest using clone", SUGGEST_USING_CLONE, (isSelected) -> SUGGEST_USING_CLONE = isSelected);
         });
     }
 }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/forEach/DisconnectedForeachInstructionInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/forEach/DisconnectedForeachInstructionInspector.java
@@ -14,13 +14,14 @@ import com.jetbrains.php.lang.psi.elements.impl.PhpPsiElementImpl;
 import com.jetbrains.php.lang.psi.elements.impl.StatementImpl;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
+import com.kalessil.phpStorm.phpInspectionsEA.options.OptionsComponent;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.ExpressionSemanticUtil;
-import net.miginfocom.swing.MigLayout;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.util.*;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /*
  * This file is part of the Php Inspections (EA Extended) package.
@@ -32,8 +33,8 @@ import java.util.*;
  */
 
 public class DisconnectedForeachInstructionInspector extends BasePhpInspection {
-    // configuration flags automatically saved by IDE
-    public boolean SUGGEST_USING_CLONE = false;
+    // Inspection options.
+    public boolean optionSuggestUsingClone = false;
 
     private static final String messageDisconnected = "This statement seems to be disconnected from its parent foreach.";
     private static final String messageUseClone     = "Objects should be created outside of a loop and cloned instead.";
@@ -134,7 +135,7 @@ public class DisconnectedForeachInstructionInspector extends BasePhpInspection {
                                     }
                                 }
 
-                                if (SUGGEST_USING_CLONE && (ExpressionType.DOM_ELEMENT_CREATE == target || ExpressionType.NEW == target)) {
+                                if (optionSuggestUsingClone && (ExpressionType.DOM_ELEMENT_CREATE == target || ExpressionType.NEW == target)) {
                                     holder.registerProblem(oneInstruction, messageUseClone, ProblemHighlightType.GENERIC_ERROR_OR_WARNING);
                                 }
                             }
@@ -313,25 +314,8 @@ public class DisconnectedForeachInstructionInspector extends BasePhpInspection {
     }
 
     public JComponent createOptionsPanel() {
-        return (new DisconnectedForeachInstructionInspector.OptionsPanel()).getComponent();
-    }
-
-    public class OptionsPanel {
-        final private JPanel optionsPanel;
-
-        final private JCheckBox suggestUsingRandomInt;
-
-        public OptionsPanel() {
-            optionsPanel = new JPanel();
-            optionsPanel.setLayout(new MigLayout());
-
-            suggestUsingRandomInt = new JCheckBox("Suggest using clone", SUGGEST_USING_CLONE);
-            suggestUsingRandomInt.addChangeListener(e -> SUGGEST_USING_CLONE = suggestUsingRandomInt.isSelected());
-            optionsPanel.add(suggestUsingRandomInt, "wrap");
-        }
-
-        public JPanel getComponent() {
-            return optionsPanel;
-        }
+        return OptionsComponent.create((component) -> {
+            component.createCheckbox("Suggest using clone", optionSuggestUsingClone, (isSelected) -> optionSuggestUsingClone = isSelected);
+        });
     }
 }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/ifs/NotOptimalIfConditionsInspection.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/ifs/NotOptimalIfConditionsInspection.java
@@ -15,12 +15,10 @@ import com.kalessil.phpStorm.phpInspectionsEA.inspectors.ifs.utils.ExpressionCos
 import com.kalessil.phpStorm.phpInspectionsEA.inspectors.ifs.utils.ExpressionsCouplingCheckUtil;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
+import com.kalessil.phpStorm.phpInspectionsEA.options.OptionsComponent;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.ExpressionSemanticUtil;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.PhpLanguageUtil;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.hierarhy.InterfacesExtractUtil;
-import net.miginfocom.swing.MigLayout;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.util.HashMap;
@@ -28,9 +26,12 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Map;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 public class NotOptimalIfConditionsInspection extends BasePhpInspection {
-    // configuration flags automatically saved by IDE
-    public boolean REPORT_LITERAL_OPERATORS = true;
+    // Inspection options.
+    public boolean optionReportLiteralOperators = true;
 
     private static final String strProblemDescriptionInstanceOfComplementarity = "Probable bug: ensure this behaves properly with 'instanceof(...)' in this scenario.";
 
@@ -92,7 +93,7 @@ public class NotOptimalIfConditionsInspection extends BasePhpInspection {
 
                     objConditionsFromStatement.clear();
 
-                    if (REPORT_LITERAL_OPERATORS) {
+                    if (optionReportLiteralOperators) {
                         AndOrWordsUsageStrategy.apply(ifStatement.getCondition(), holder);
                     }
                 }
@@ -112,7 +113,7 @@ public class NotOptimalIfConditionsInspection extends BasePhpInspection {
 
                         objConditionsFromStatement.clear();
 
-                        if (REPORT_LITERAL_OPERATORS) {
+                        if (optionReportLiteralOperators) {
                             AndOrWordsUsageStrategy.apply(objElseIf.getCondition(), holder);
                         }
                     }
@@ -554,25 +555,8 @@ public class NotOptimalIfConditionsInspection extends BasePhpInspection {
     }
 
     public JComponent createOptionsPanel() {
-        return (new NotOptimalIfConditionsInspection.OptionsPanel()).getComponent();
-    }
-
-    private class OptionsPanel {
-        final private JPanel optionsPanel;
-
-        final private JCheckBox reportLiteralOperators;
-
-        public OptionsPanel() {
-            optionsPanel = new JPanel();
-            optionsPanel.setLayout(new MigLayout());
-
-            reportLiteralOperators = new JCheckBox("Report literal and/or operators", REPORT_LITERAL_OPERATORS);
-            reportLiteralOperators.addChangeListener(e -> REPORT_LITERAL_OPERATORS = reportLiteralOperators.isSelected());
-            optionsPanel.add(reportLiteralOperators, "wrap");
-        }
-
-        JPanel getComponent() {
-            return optionsPanel;
-        }
+        return OptionsComponent.create((component) -> {
+            component.createCheckbox("Report literal and/or operators", optionReportLiteralOperators, (isSelected) -> optionReportLiteralOperators = isSelected);
+        });
     }
 }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/ifs/NotOptimalIfConditionsInspection.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/ifs/NotOptimalIfConditionsInspection.java
@@ -31,7 +31,7 @@ import org.jetbrains.annotations.Nullable;
 
 public class NotOptimalIfConditionsInspection extends BasePhpInspection {
     // Inspection options.
-    public boolean optionReportLiteralOperators = true;
+    public boolean REPORT_LITERAL_OPERATORS = true;
 
     private static final String strProblemDescriptionInstanceOfComplementarity = "Probable bug: ensure this behaves properly with 'instanceof(...)' in this scenario.";
 
@@ -93,7 +93,7 @@ public class NotOptimalIfConditionsInspection extends BasePhpInspection {
 
                     objConditionsFromStatement.clear();
 
-                    if (optionReportLiteralOperators) {
+                    if (REPORT_LITERAL_OPERATORS) {
                         AndOrWordsUsageStrategy.apply(ifStatement.getCondition(), holder);
                     }
                 }
@@ -113,7 +113,7 @@ public class NotOptimalIfConditionsInspection extends BasePhpInspection {
 
                         objConditionsFromStatement.clear();
 
-                        if (optionReportLiteralOperators) {
+                        if (REPORT_LITERAL_OPERATORS) {
                             AndOrWordsUsageStrategy.apply(objElseIf.getCondition(), holder);
                         }
                     }
@@ -556,7 +556,7 @@ public class NotOptimalIfConditionsInspection extends BasePhpInspection {
 
     public JComponent createOptionsPanel() {
         return OptionsComponent.create((component) -> {
-            component.createCheckbox("Report literal and/or operators", optionReportLiteralOperators, (isSelected) -> optionReportLiteralOperators = isSelected);
+            component.createCheckbox("Report literal and/or operators", REPORT_LITERAL_OPERATORS, (isSelected) -> REPORT_LITERAL_OPERATORS = isSelected);
         });
     }
 }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/languageConstructions/ClassConstantCanBeUsedInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/languageConstructions/ClassConstantCanBeUsedInspector.java
@@ -44,9 +44,9 @@ import org.jetbrains.annotations.NotNull;
 
 public class ClassConstantCanBeUsedInspector extends BasePhpInspection {
     // Inspection options.
-    public boolean optionImportClassesOnQF = true;
-    public boolean optionUseRelativeQF     = true;
-    public boolean optionLookRootNsUp      = false;
+    public boolean IMPORT_CLASSES_ON_QF = true;
+    public boolean USE_RELATIVE_QF      = true;
+    public boolean LOOK_ROOT_NS_UP      = false;
 
     private static final String messagePattern   = "Perhaps this can be replaced with %c%::class.";
     private static final String messageUseStatic = "'static::class' can be used instead.";
@@ -112,7 +112,7 @@ public class ClassConstantCanBeUsedInspector extends BasePhpInspection {
                     if (isFull) {
                         namesToLookup.add(normalizedContents);
                     } else {
-                        if (optionLookRootNsUp || normalizedContents.contains("\\")) {
+                        if (LOOK_ROOT_NS_UP || normalizedContents.contains("\\")) {
                             normalizedContents = '\\' + normalizedContents;
                             namesToLookup.add(normalizedContents);
                         }
@@ -134,7 +134,7 @@ public class ClassConstantCanBeUsedInspector extends BasePhpInspection {
                             final String message = messagePattern.replace("%c%", normalizedContents);
                             holder.registerProblem(
                                 expression, message, ProblemHighlightType.WEAK_WARNING,
-                                new TheLocalFix(normalizedContents, optionImportClassesOnQF, optionUseRelativeQF)
+                                new TheLocalFix(normalizedContents, IMPORT_CLASSES_ON_QF, USE_RELATIVE_QF)
                             );
                         }
                     }
@@ -283,9 +283,9 @@ public class ClassConstantCanBeUsedInspector extends BasePhpInspection {
 
     public JComponent createOptionsPanel() {
         return OptionsComponent.create((component) -> {
-            component.createCheckbox("Lookup root namespace classes", optionLookRootNsUp, (isSelected) -> optionLookRootNsUp = isSelected);
-            component.createCheckbox("Import classes automatically", optionImportClassesOnQF, (isSelected) -> optionImportClassesOnQF = isSelected);
-            component.createCheckbox("Use relative QN where possible", optionUseRelativeQF, (isSelected) -> optionUseRelativeQF = isSelected);
+            component.createCheckbox("Lookup root namespace classes", LOOK_ROOT_NS_UP, (isSelected) -> LOOK_ROOT_NS_UP = isSelected);
+            component.createCheckbox("Import classes automatically", IMPORT_CLASSES_ON_QF, (isSelected) -> IMPORT_CLASSES_ON_QF = isSelected);
+            component.createCheckbox("Use relative QN where possible", USE_RELATIVE_QF, (isSelected) -> USE_RELATIVE_QF = isSelected);
         });
     }
 }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/languageConstructions/ClassConstantCanBeUsedInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/languageConstructions/ClassConstantCanBeUsedInspector.java
@@ -20,10 +20,9 @@ import com.jetbrains.php.lang.psi.elements.*;
 import com.kalessil.phpStorm.phpInspectionsEA.fixers.UseSuggestedReplacementFixer;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
+import com.kalessil.phpStorm.phpInspectionsEA.options.OptionsComponent;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.ExpressionSemanticUtil;
-import net.miginfocom.swing.MigLayout;
 import org.apache.commons.lang.StringUtils;
-import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.util.Collection;
@@ -31,6 +30,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.jetbrains.annotations.NotNull;
 
 /*
  * This file is part of the Php Inspections (EA Extended) package.
@@ -42,10 +43,10 @@ import java.util.regex.Pattern;
  */
 
 public class ClassConstantCanBeUsedInspector extends BasePhpInspection {
-    // configuration flags automatically saved by IDE
-    public boolean IMPORT_CLASSES_ON_QF = true;
-    public boolean USE_RELATIVE_QF      = true;
-    public boolean LOOK_ROOT_NS_UP      = false;
+    // Inspection options.
+    public boolean optionImportClassesOnQF = true;
+    public boolean optionUseRelativeQF     = true;
+    public boolean optionLookRootNsUp      = false;
 
     private static final String messagePattern   = "Perhaps this can be replaced with %c%::class.";
     private static final String messageUseStatic = "'static::class' can be used instead.";
@@ -111,7 +112,7 @@ public class ClassConstantCanBeUsedInspector extends BasePhpInspection {
                     if (isFull) {
                         namesToLookup.add(normalizedContents);
                     } else {
-                        if (LOOK_ROOT_NS_UP || normalizedContents.contains("\\")) {
+                        if (optionLookRootNsUp || normalizedContents.contains("\\")) {
                             normalizedContents = '\\' + normalizedContents;
                             namesToLookup.add(normalizedContents);
                         }
@@ -133,7 +134,7 @@ public class ClassConstantCanBeUsedInspector extends BasePhpInspection {
                             final String message = messagePattern.replace("%c%", normalizedContents);
                             holder.registerProblem(
                                 expression, message, ProblemHighlightType.WEAK_WARNING,
-                                new TheLocalFix(normalizedContents, IMPORT_CLASSES_ON_QF, USE_RELATIVE_QF)
+                                new TheLocalFix(normalizedContents, optionImportClassesOnQF, optionUseRelativeQF)
                             );
                         }
                     }
@@ -281,35 +282,10 @@ public class ClassConstantCanBeUsedInspector extends BasePhpInspection {
     }
 
     public JComponent createOptionsPanel() {
-        return (new ClassConstantCanBeUsedInspector.OptionsPanel()).getComponent();
-    }
-
-    public class OptionsPanel {
-        final private JPanel optionsPanel;
-
-        final private JCheckBox lookRootNamespaceUp;
-        final private JCheckBox importClassesAutomatically;
-        final private JCheckBox useRelativeQNs;
-
-        public OptionsPanel() {
-            optionsPanel = new JPanel();
-            optionsPanel.setLayout(new MigLayout());
-
-            lookRootNamespaceUp = new JCheckBox("Lookup root namespace classes", LOOK_ROOT_NS_UP);
-            lookRootNamespaceUp.addChangeListener(e -> LOOK_ROOT_NS_UP = lookRootNamespaceUp.isSelected());
-            optionsPanel.add(lookRootNamespaceUp, "wrap");
-
-            importClassesAutomatically = new JCheckBox("Import classes automatically", IMPORT_CLASSES_ON_QF);
-            importClassesAutomatically.addChangeListener(e -> IMPORT_CLASSES_ON_QF = importClassesAutomatically.isSelected());
-            optionsPanel.add(importClassesAutomatically, "wrap");
-
-            useRelativeQNs = new JCheckBox("Use relative QN where possible", USE_RELATIVE_QF);
-            useRelativeQNs.addChangeListener(e -> USE_RELATIVE_QF = useRelativeQNs.isSelected());
-            optionsPanel.add(useRelativeQNs, "wrap");
-        }
-
-        public JPanel getComponent() {
-            return optionsPanel;
-        }
+        return OptionsComponent.create((component) -> {
+            component.createCheckbox("Lookup root namespace classes", optionLookRootNsUp, (isSelected) -> optionLookRootNsUp = isSelected);
+            component.createCheckbox("Import classes automatically", optionImportClassesOnQF, (isSelected) -> optionImportClassesOnQF = isSelected);
+            component.createCheckbox("Use relative QN where possible", optionUseRelativeQF, (isSelected) -> optionUseRelativeQF = isSelected);
+        });
     }
 }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/languageConstructions/StaticInvocationViaThisInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/languageConstructions/StaticInvocationViaThisInspector.java
@@ -15,16 +15,16 @@ import com.jetbrains.php.lang.psi.elements.MethodReference;
 import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
+import com.kalessil.phpStorm.phpInspectionsEA.options.OptionsComponent;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.OpenapiPsiSearchUtil;
-import net.miginfocom.swing.MigLayout;
-import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 
+import org.jetbrains.annotations.NotNull;
+
 public class StaticInvocationViaThisInspector extends BasePhpInspection {
-    // configuration flags automatically saved by IDE
-    @SuppressWarnings("WeakerAccess")
-    public boolean RESPECT_PHPUNIT_STANDARDS = true;
+    // Inspection options.
+    private boolean optionRespectPhpUnitStandards = true;
 
     private static final String messageThisUsed       = "'static::%m%(...)' should be used instead.";
     private static final String messageExpressionUsed = "'...::%m%(...)' should be used instead.";
@@ -70,7 +70,7 @@ public class StaticInvocationViaThisInspector extends BasePhpInspection {
                     }
 
                     /* PHP Unit's official docs saying to use $this, follow the guidance */
-                    if (RESPECT_PHPUNIT_STANDARDS) {
+                    if (optionRespectPhpUnitStandards) {
                         final String classFqn = clazz.getFQN();
                         if (classFqn.startsWith("\\PHPUnit_Framework_") || classFqn.startsWith("\\PHPUnit\\Framework\\")) {
                             return;
@@ -135,25 +135,8 @@ public class StaticInvocationViaThisInspector extends BasePhpInspection {
     }
 
     public JComponent createOptionsPanel() {
-        return (new StaticInvocationViaThisInspector.OptionsPanel()).getComponent();
-    }
-
-    private class OptionsPanel {
-        final private JPanel optionsPanel;
-
-        final private JCheckBox respectPhpunitStandards;
-
-        public OptionsPanel() {
-            optionsPanel = new JPanel();
-            optionsPanel.setLayout(new MigLayout());
-
-            respectPhpunitStandards = new JCheckBox("Follow PHPUnit standards", RESPECT_PHPUNIT_STANDARDS);
-            respectPhpunitStandards.addChangeListener(e -> RESPECT_PHPUNIT_STANDARDS = respectPhpunitStandards.isSelected());
-            optionsPanel.add(respectPhpunitStandards, "wrap");
-        }
-
-        public JPanel getComponent() {
-            return optionsPanel;
-        }
+        return OptionsComponent.create((component) -> {
+            component.createCheckbox("Follow PHPUnit standards", optionRespectPhpUnitStandards, (isSelected) -> optionRespectPhpUnitStandards = isSelected);
+        });
     }
 }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/languageConstructions/StaticInvocationViaThisInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/languageConstructions/StaticInvocationViaThisInspector.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class StaticInvocationViaThisInspector extends BasePhpInspection {
     // Inspection options.
-    private boolean optionRespectPhpUnitStandards = true;
+    private boolean RESPECT_PHPUNIT_STANDARDS = true;
 
     private static final String messageThisUsed       = "'static::%m%(...)' should be used instead.";
     private static final String messageExpressionUsed = "'...::%m%(...)' should be used instead.";
@@ -70,7 +70,7 @@ public class StaticInvocationViaThisInspector extends BasePhpInspection {
                     }
 
                     /* PHP Unit's official docs saying to use $this, follow the guidance */
-                    if (optionRespectPhpUnitStandards) {
+                    if (RESPECT_PHPUNIT_STANDARDS) {
                         final String classFqn = clazz.getFQN();
                         if (classFqn.startsWith("\\PHPUnit_Framework_") || classFqn.startsWith("\\PHPUnit\\Framework\\")) {
                             return;
@@ -136,7 +136,7 @@ public class StaticInvocationViaThisInspector extends BasePhpInspection {
 
     public JComponent createOptionsPanel() {
         return OptionsComponent.create((component) -> {
-            component.createCheckbox("Follow PHPUnit standards", optionRespectPhpUnitStandards, (isSelected) -> optionRespectPhpUnitStandards = isSelected);
+            component.createCheckbox("Follow PHPUnit standards", RESPECT_PHPUNIT_STANDARDS, (isSelected) -> RESPECT_PHPUNIT_STANDARDS = isSelected);
         });
     }
 }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/magicMethods/ImplicitMagicMethodCallInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/magicMethods/ImplicitMagicMethodCallInspector.java
@@ -15,13 +15,14 @@ import com.jetbrains.php.lang.psi.elements.MethodReference;
 import com.jetbrains.php.lang.psi.elements.UnaryExpression;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
+import com.kalessil.phpStorm.phpInspectionsEA.options.OptionsComponent;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.ExpressionSemanticUtil;
-import net.miginfocom.swing.MigLayout;
-import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.util.HashSet;
 import java.util.Set;
+
+import org.jetbrains.annotations.NotNull;
 
 /*
  * This file is part of the Php Inspections (EA Extended) package.
@@ -33,8 +34,8 @@ import java.util.Set;
  */
 
 public class ImplicitMagicMethodCallInspector extends BasePhpInspection {
-    // configuration flags automatically saved by IDE
-    public boolean SUGGEST_USING_STRING_CASTING = false;
+    // Inspection options.
+    public boolean optionSuggestUsingStringCasting = false;
 
     private static final String message              = "Implicit magic method calls should be avoided as these methods are used by PHP internals.";
     private static final String patternStringCasting = "Please use (string) %o% instead.";
@@ -77,14 +78,14 @@ public class ImplicitMagicMethodCallInspector extends BasePhpInspection {
                         !referenceObject.equals("$this") && !referenceObject.equals("parent")
                     ) {
                         /* __toString is a special case */
-                        if (SUGGEST_USING_STRING_CASTING && methodName.equals("__toString")) {
+                        if (optionSuggestUsingStringCasting && methodName.equals("__toString")) {
                             final String message = patternStringCasting.replace("%o%", referenceObject);
                             holder.registerProblem(reference, message, ProblemHighlightType.GENERIC_ERROR_OR_WARNING, new UseStringCastingLocalFix());
 
                             return;
                         }
                         /* allow calling __toString, as a developer don't want hints on this */
-                        if (!SUGGEST_USING_STRING_CASTING && methodName.equals("__toString")) {
+                        if (!optionSuggestUsingStringCasting && methodName.equals("__toString")) {
                             return;
                         }
 
@@ -101,7 +102,7 @@ public class ImplicitMagicMethodCallInspector extends BasePhpInspection {
                             return;
                         }
                         /* allow calling __toString, as a developer don't want hints on this */
-                        if (!SUGGEST_USING_STRING_CASTING && methodName.equals("__toString")) {
+                        if (!optionSuggestUsingStringCasting && methodName.equals("__toString")) {
                             return;
                         }
 
@@ -139,25 +140,8 @@ public class ImplicitMagicMethodCallInspector extends BasePhpInspection {
     }
 
     public JComponent createOptionsPanel() {
-        return (new ImplicitMagicMethodCallInspector.OptionsPanel()).getComponent();
-    }
-
-    private class OptionsPanel {
-        final private JPanel optionsPanel;
-
-        final private JCheckBox suggestUsingStringCasting;
-
-        public OptionsPanel() {
-            optionsPanel = new JPanel();
-            optionsPanel.setLayout(new MigLayout());
-
-            suggestUsingStringCasting = new JCheckBox("Suggest using (string)...", SUGGEST_USING_STRING_CASTING);
-            suggestUsingStringCasting.addChangeListener(e -> SUGGEST_USING_STRING_CASTING = suggestUsingStringCasting.isSelected());
-            optionsPanel.add(suggestUsingStringCasting, "wrap");
-        }
-
-        public JPanel getComponent() {
-            return optionsPanel;
-        }
+        return OptionsComponent.create((component) -> {
+            component.createCheckbox("Suggest using (string)...", optionSuggestUsingStringCasting, (isSelected) -> optionSuggestUsingStringCasting = isSelected);
+        });
     }
 }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/magicMethods/ImplicitMagicMethodCallInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/magicMethods/ImplicitMagicMethodCallInspector.java
@@ -35,7 +35,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class ImplicitMagicMethodCallInspector extends BasePhpInspection {
     // Inspection options.
-    public boolean optionSuggestUsingStringCasting = false;
+    public boolean SUGGEST_USING_STRING_CASTING = false;
 
     private static final String message              = "Implicit magic method calls should be avoided as these methods are used by PHP internals.";
     private static final String patternStringCasting = "Please use (string) %o% instead.";
@@ -78,14 +78,14 @@ public class ImplicitMagicMethodCallInspector extends BasePhpInspection {
                         !referenceObject.equals("$this") && !referenceObject.equals("parent")
                     ) {
                         /* __toString is a special case */
-                        if (optionSuggestUsingStringCasting && methodName.equals("__toString")) {
+                        if (SUGGEST_USING_STRING_CASTING && methodName.equals("__toString")) {
                             final String message = patternStringCasting.replace("%o%", referenceObject);
                             holder.registerProblem(reference, message, ProblemHighlightType.GENERIC_ERROR_OR_WARNING, new UseStringCastingLocalFix());
 
                             return;
                         }
                         /* allow calling __toString, as a developer don't want hints on this */
-                        if (!optionSuggestUsingStringCasting && methodName.equals("__toString")) {
+                        if (!SUGGEST_USING_STRING_CASTING && methodName.equals("__toString")) {
                             return;
                         }
 
@@ -102,7 +102,7 @@ public class ImplicitMagicMethodCallInspector extends BasePhpInspection {
                             return;
                         }
                         /* allow calling __toString, as a developer don't want hints on this */
-                        if (!optionSuggestUsingStringCasting && methodName.equals("__toString")) {
+                        if (!SUGGEST_USING_STRING_CASTING && methodName.equals("__toString")) {
                             return;
                         }
 
@@ -141,7 +141,7 @@ public class ImplicitMagicMethodCallInspector extends BasePhpInspection {
 
     public JComponent createOptionsPanel() {
         return OptionsComponent.create((component) -> {
-            component.createCheckbox("Suggest using (string)...", optionSuggestUsingStringCasting, (isSelected) -> optionSuggestUsingStringCasting = isSelected);
+            component.createCheckbox("Suggest using (string)...", SUGGEST_USING_STRING_CASTING, (isSelected) -> SUGGEST_USING_STRING_CASTING = isSelected);
         });
     }
 }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/phpUnit/PhpUnitTestsInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/phpUnit/PhpUnitTestsInspector.java
@@ -20,12 +20,13 @@ import com.jetbrains.php.lang.psi.elements.*;
 import com.kalessil.phpStorm.phpInspectionsEA.inspectors.phpUnit.strategy.*;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
+import com.kalessil.phpStorm.phpInspectionsEA.options.OptionsComponent;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.NamedElementUtil;
-import net.miginfocom.swing.MigLayout;
-import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.util.*;
+
+import org.jetbrains.annotations.NotNull;
 
 /*
  * This file is part of the Php Inspections (EA Extended) package.
@@ -37,9 +38,10 @@ import java.util.*;
  */
 
 public class PhpUnitTestsInspector extends BasePhpInspection {
-    // configuration flags automatically saved by IDE
-    @SuppressWarnings("WeakerAccess")
-    public boolean SUGGEST_TO_USE_ASSERTSAME    = false;
+    // Inspection options.
+    private boolean optionSuggestToUseAssertSame = false;
+
+    // TODO: refactor to avoid this.
     public boolean WORKAROUND_COVERS_REFERENCES = false;
 
     private final static String messageDepends = "@depends referencing to a non-existing entity.";
@@ -166,7 +168,7 @@ public class PhpUnitTestsInspector extends BasePhpInspection {
                 ) {
                     return;
                 }
-                if (SUGGEST_TO_USE_ASSERTSAME) {
+                if (optionSuggestToUseAssertSame) {
                     @SuppressWarnings({"unused", "UnusedAssignment"})
                     boolean strictAsserts =
                         AssertSameStrategy.apply(methodName, reference, holder) ||
@@ -209,26 +211,9 @@ public class PhpUnitTestsInspector extends BasePhpInspection {
     }
 
     public JComponent createOptionsPanel() {
-        return (new PhpUnitTestsInspector.OptionsPanel()).getComponent();
-    }
-
-    public class OptionsPanel {
-        final private JPanel optionsPanel;
-
-        final private JCheckBox suggestToUseAssertSame;
-
-        public OptionsPanel() {
-            optionsPanel = new JPanel();
-            optionsPanel.setLayout(new MigLayout());
-
-            suggestToUseAssertSame = new JCheckBox("Suggest to use assertSame", SUGGEST_TO_USE_ASSERTSAME);
-            suggestToUseAssertSame.addChangeListener(e -> SUGGEST_TO_USE_ASSERTSAME = suggestToUseAssertSame.isSelected());
-            optionsPanel.add(suggestToUseAssertSame, "wrap");
-        }
-
-        public JPanel getComponent() {
-            return optionsPanel;
-        }
+        return OptionsComponent.create((component) -> {
+            component.createCheckbox("Suggest to use assertSame", optionSuggestToUseAssertSame, (isSelected) -> optionSuggestToUseAssertSame = isSelected);
+        });
     }
 
     private static class AmbiguousTestAnnotationLocalFix implements LocalQuickFix {

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/phpUnit/PhpUnitTestsInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/phpUnit/PhpUnitTestsInspector.java
@@ -39,7 +39,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class PhpUnitTestsInspector extends BasePhpInspection {
     // Inspection options.
-    private boolean optionSuggestToUseAssertSame = false;
+    private boolean SUGGEST_TO_USE_ASSERTSAME = false;
 
     // TODO: refactor to avoid this.
     public boolean WORKAROUND_COVERS_REFERENCES = false;
@@ -168,7 +168,7 @@ public class PhpUnitTestsInspector extends BasePhpInspection {
                 ) {
                     return;
                 }
-                if (optionSuggestToUseAssertSame) {
+                if (SUGGEST_TO_USE_ASSERTSAME) {
                     @SuppressWarnings({"unused", "UnusedAssignment"})
                     boolean strictAsserts =
                         AssertSameStrategy.apply(methodName, reference, holder) ||
@@ -212,7 +212,7 @@ public class PhpUnitTestsInspector extends BasePhpInspection {
 
     public JComponent createOptionsPanel() {
         return OptionsComponent.create((component) -> {
-            component.createCheckbox("Suggest to use assertSame", optionSuggestToUseAssertSame, (isSelected) -> optionSuggestToUseAssertSame = isSelected);
+            component.createCheckbox("Suggest to use assertSame", SUGGEST_TO_USE_ASSERTSAME, (isSelected) -> SUGGEST_TO_USE_ASSERTSAME = isSelected);
         });
     }
 

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/classes/AccessModifierPresentedInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/classes/AccessModifierPresentedInspector.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class AccessModifierPresentedInspector extends BasePhpInspection {
     // Inspection options.
-    private boolean optionAnalyzeInterfaces = true;
+    private boolean ANALYZE_INTERFACES = true;
 
     private static final String messagePattern = "'%s%' should be declared with access modifier.";
 
@@ -41,7 +41,7 @@ public class AccessModifierPresentedInspector extends BasePhpInspection {
         return new BasePhpElementVisitor() {
             public void visitPhpClass(PhpClass clazz) {
                 /* community request: interfaces have only public methods, what is default access levels */
-                if (!optionAnalyzeInterfaces && clazz.isInterface()){
+                if (!ANALYZE_INTERFACES && clazz.isInterface()){
                     return;
                 }
 
@@ -78,7 +78,7 @@ public class AccessModifierPresentedInspector extends BasePhpInspection {
 
     public JComponent createOptionsPanel() {
         return OptionsComponent.create((component) -> {
-            component.createCheckbox("Analyze interfaces", optionAnalyzeInterfaces, (isSelected) -> optionAnalyzeInterfaces = isSelected);
+            component.createCheckbox("Analyze interfaces", ANALYZE_INTERFACES, (isSelected) -> ANALYZE_INTERFACES = isSelected);
         });
     }
 

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/classes/AccessModifierPresentedInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/classes/AccessModifierPresentedInspector.java
@@ -17,16 +17,16 @@ import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.jetbrains.php.lang.psi.elements.PhpModifierList;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
+import com.kalessil.phpStorm.phpInspectionsEA.options.OptionsComponent;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.NamedElementUtil;
-import net.miginfocom.swing.MigLayout;
-import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 
+import org.jetbrains.annotations.NotNull;
+
 public class AccessModifierPresentedInspector extends BasePhpInspection {
-    // configuration flags automatically saved by IDE
-    @SuppressWarnings("WeakerAccess")
-    public boolean ANALYZE_INTERFACES = true;
+    // Inspection options.
+    private boolean optionAnalyzeInterfaces = true;
 
     private static final String messagePattern = "'%s%' should be declared with access modifier.";
 
@@ -41,7 +41,7 @@ public class AccessModifierPresentedInspector extends BasePhpInspection {
         return new BasePhpElementVisitor() {
             public void visitPhpClass(PhpClass clazz) {
                 /* community request: interfaces have only public methods, what is default access levels */
-                if (!ANALYZE_INTERFACES && clazz.isInterface()){
+                if (!optionAnalyzeInterfaces && clazz.isInterface()){
                     return;
                 }
 
@@ -77,26 +77,9 @@ public class AccessModifierPresentedInspector extends BasePhpInspection {
     }
 
     public JComponent createOptionsPanel() {
-        return (new AccessModifierPresentedInspector.OptionsPanel()).getComponent();
-    }
-
-    private class OptionsPanel {
-        final private JPanel optionsPanel;
-
-        final private JCheckBox analyzeInterfaces;
-
-        public OptionsPanel() {
-            optionsPanel = new JPanel();
-            optionsPanel.setLayout(new MigLayout());
-
-            analyzeInterfaces = new JCheckBox("Analyze interfaces", ANALYZE_INTERFACES);
-            analyzeInterfaces.addChangeListener(e -> ANALYZE_INTERFACES = analyzeInterfaces.isSelected());
-            optionsPanel.add(analyzeInterfaces, "wrap");
-        }
-
-        JPanel getComponent() {
-            return optionsPanel;
-        }
+        return OptionsComponent.create((component) -> {
+            component.createCheckbox("Analyze interfaces", optionAnalyzeInterfaces, (isSelected) -> optionAnalyzeInterfaces = isSelected);
+        });
     }
 
     private static class TheLocalFix implements LocalQuickFix {

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/classes/ClassOverridesFieldOfSuperClassInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/classes/ClassOverridesFieldOfSuperClassInspector.java
@@ -31,7 +31,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class ClassOverridesFieldOfSuperClassInspector extends BasePhpInspection {
     // Inspection options.
-    private boolean optionReportPrivateRedefinition = true;
+    private boolean REPORT_PRIVATE_REDEFINITION = true;
 
     private static final String patternShadows            = "Field '%p%' is already defined in %c%, check our online documentation for options.";
     private static final String patternProtectedCandidate = "Likely needs to be protected (already defined in %c%).";
@@ -80,7 +80,7 @@ public class ClassOverridesFieldOfSuperClassInspector extends BasePhpInspection 
 
                         /* re-defining private fields with the same name is pretty suspicious itself */
                         if (superclassField.getModifier().isPrivate()) {
-                            if (optionReportPrivateRedefinition) {
+                            if (REPORT_PRIVATE_REDEFINITION) {
                                 final String message = patternProtectedCandidate.replace("%c%", superClassFQN);
                                 holder.registerProblem(ownFieldParent, message, ProblemHighlightType.WEAK_WARNING);
                             }
@@ -101,7 +101,7 @@ public class ClassOverridesFieldOfSuperClassInspector extends BasePhpInspection 
 
     public JComponent createOptionsPanel() {
         return OptionsComponent.create((component) -> {
-            component.createCheckbox("Report re-defining private fields", optionReportPrivateRedefinition, (isSelected) -> optionReportPrivateRedefinition = isSelected);
+            component.createCheckbox("Report re-defining private fields", REPORT_PRIVATE_REDEFINITION, (isSelected) -> REPORT_PRIVATE_REDEFINITION = isSelected);
         });
     }
 }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/classes/ClassOverridesFieldOfSuperClassInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/classes/ClassOverridesFieldOfSuperClassInspector.java
@@ -10,14 +10,15 @@ import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.jetbrains.php.lang.psi.elements.PhpModifier;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
+import com.kalessil.phpStorm.phpInspectionsEA.options.OptionsComponent;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.ExpressionSemanticUtil;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.FileSystemUtil;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.NamedElementUtil;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.hierarhy.InterfacesExtractUtil;
-import net.miginfocom.swing.MigLayout;
-import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
+
+import org.jetbrains.annotations.NotNull;
 
 /*
  * This file is part of the Php Inspections (EA Extended) package.
@@ -29,9 +30,8 @@ import javax.swing.*;
  */
 
 public class ClassOverridesFieldOfSuperClassInspector extends BasePhpInspection {
-    // configuration flags automatically saved by IDE
-    @SuppressWarnings("WeakerAccess")
-    public boolean REPORT_PRIVATE_REDEFINITION = true;
+    // Inspection options.
+    private boolean optionReportPrivateRedefinition = true;
 
     private static final String patternShadows            = "Field '%p%' is already defined in %c%, check our online documentation for options.";
     private static final String patternProtectedCandidate = "Likely needs to be protected (already defined in %c%).";
@@ -80,7 +80,7 @@ public class ClassOverridesFieldOfSuperClassInspector extends BasePhpInspection 
 
                         /* re-defining private fields with the same name is pretty suspicious itself */
                         if (superclassField.getModifier().isPrivate()) {
-                            if (REPORT_PRIVATE_REDEFINITION) {
+                            if (optionReportPrivateRedefinition) {
                                 final String message = patternProtectedCandidate.replace("%c%", superClassFQN);
                                 holder.registerProblem(ownFieldParent, message, ProblemHighlightType.WEAK_WARNING);
                             }
@@ -100,25 +100,8 @@ public class ClassOverridesFieldOfSuperClassInspector extends BasePhpInspection 
     }
 
     public JComponent createOptionsPanel() {
-        return (new ClassOverridesFieldOfSuperClassInspector.OptionsPanel()).getComponent();
-    }
-
-    public class OptionsPanel {
-        final private JPanel optionsPanel;
-
-        final private JCheckBox reportPrivateRedefinition;
-
-        public OptionsPanel() {
-            optionsPanel = new JPanel();
-            optionsPanel.setLayout(new MigLayout());
-
-            reportPrivateRedefinition = new JCheckBox("Report re-defining private fields", REPORT_PRIVATE_REDEFINITION);
-            reportPrivateRedefinition.addChangeListener(e -> REPORT_PRIVATE_REDEFINITION = reportPrivateRedefinition.isSelected());
-            optionsPanel.add(reportPrivateRedefinition, "wrap");
-        }
-
-        public JPanel getComponent() {
-            return optionsPanel;
-        }
+        return OptionsComponent.create((component) -> {
+            component.createCheckbox("Report re-defining private fields", optionReportPrivateRedefinition, (isSelected) -> optionReportPrivateRedefinition = isSelected);
+        });
     }
 }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/classes/SingletonFactoryPatternViolationInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/classes/SingletonFactoryPatternViolationInspector.java
@@ -19,7 +19,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class SingletonFactoryPatternViolationInspector extends BasePhpInspection {
     // Inspection options.
-    public boolean optionSuggestOverridingClone = false;
+    public boolean SUGGEST_OVERRIDING_CLONE = false;
 
     private static final String messageClone                = "Singleton should also override __clone to prevent copying the instance";
     private static final String messageFactoryOrSingleton   = "Ensure that one of public getInstance/create*/from* methods are defined.";
@@ -49,7 +49,7 @@ public class SingletonFactoryPatternViolationInspector extends BasePhpInspection
                 final Method getInstance     = clazz.findOwnMethodByName("getInstance");
                 final boolean hasGetInstance = (null != getInstance && getInstance.getAccess().isPublic());
                 if (hasGetInstance) {
-                    if (optionSuggestOverridingClone && null == clazz.findOwnMethodByName("__clone")) {
+                    if (SUGGEST_OVERRIDING_CLONE && null == clazz.findOwnMethodByName("__clone")) {
                         holder.registerProblem(nameNode, messageClone, ProblemHighlightType.WEAK_WARNING);
                     }
 
@@ -79,7 +79,7 @@ public class SingletonFactoryPatternViolationInspector extends BasePhpInspection
 
     public JComponent createOptionsPanel() {
         return OptionsComponent.create((component) -> {
-            component.createCheckbox("Suggest overriding __clone", optionSuggestOverridingClone, (isSelected) -> optionSuggestOverridingClone = isSelected);
+            component.createCheckbox("Suggest overriding __clone", SUGGEST_OVERRIDING_CLONE, (isSelected) -> SUGGEST_OVERRIDING_CLONE = isSelected);
         });
     }
 }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/classes/SingletonFactoryPatternViolationInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/classes/SingletonFactoryPatternViolationInspector.java
@@ -10,15 +10,16 @@ import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.jetbrains.php.lang.psi.elements.PhpModifier;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
+import com.kalessil.phpStorm.phpInspectionsEA.options.OptionsComponent;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.NamedElementUtil;
-import net.miginfocom.swing.MigLayout;
-import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 
+import org.jetbrains.annotations.NotNull;
+
 public class SingletonFactoryPatternViolationInspector extends BasePhpInspection {
-    // configuration flags automatically saved by IDE
-    public boolean SUGGEST_OVERRIDING_CLONE = false;
+    // Inspection options.
+    public boolean optionSuggestOverridingClone = false;
 
     private static final String messageClone                = "Singleton should also override __clone to prevent copying the instance";
     private static final String messageFactoryOrSingleton   = "Ensure that one of public getInstance/create*/from* methods are defined.";
@@ -48,7 +49,7 @@ public class SingletonFactoryPatternViolationInspector extends BasePhpInspection
                 final Method getInstance     = clazz.findOwnMethodByName("getInstance");
                 final boolean hasGetInstance = (null != getInstance && getInstance.getAccess().isPublic());
                 if (hasGetInstance) {
-                    if (SUGGEST_OVERRIDING_CLONE && null == clazz.findOwnMethodByName("__clone")) {
+                    if (optionSuggestOverridingClone && null == clazz.findOwnMethodByName("__clone")) {
                         holder.registerProblem(nameNode, messageClone, ProblemHighlightType.WEAK_WARNING);
                     }
 
@@ -77,25 +78,8 @@ public class SingletonFactoryPatternViolationInspector extends BasePhpInspection
     }
 
     public JComponent createOptionsPanel() {
-        return (new OptionsPanel()).getComponent();
-    }
-
-    public class OptionsPanel {
-        final private JPanel optionsPanel;
-
-        final private JCheckBox suggestOverridingClone;
-
-        public OptionsPanel() {
-            optionsPanel = new JPanel();
-            optionsPanel.setLayout(new MigLayout());
-
-            suggestOverridingClone = new JCheckBox("Suggest overriding __clone", SUGGEST_OVERRIDING_CLONE);
-            suggestOverridingClone.addChangeListener(e -> SUGGEST_OVERRIDING_CLONE = suggestOverridingClone.isSelected());
-            optionsPanel.add(suggestOverridingClone, "wrap");
-        }
-
-        public JPanel getComponent() {
-            return optionsPanel;
-        }
+        return OptionsComponent.create((component) -> {
+            component.createCheckbox("Suggest overriding __clone", optionSuggestOverridingClone, (isSelected) -> optionSuggestOverridingClone = isSelected);
+        });
     }
 }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/options/OptionsComponent.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/options/OptionsComponent.java
@@ -1,0 +1,163 @@
+package com.kalessil.phpStorm.phpInspectionsEA.options;
+
+import com.kalessil.phpStorm.phpInspectionsEA.gui.PrettyListControl;
+import net.miginfocom.swing.MigLayout;
+
+import javax.swing.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Helps on constructions of a normalized inspection options list for IntelliJ's IDE.
+ */
+public class OptionsComponent {
+    /**
+     * Stores the options panel.
+     */
+    private final JPanel optionsPanel;
+
+    /**
+     * Construct the OptionsComponent.
+     */
+    private OptionsComponent() {
+        optionsPanel = new JPanel();
+        optionsPanel.setLayout(new MigLayout());
+    }
+
+    /**
+     * Creates a new OptionsComponent.
+     *
+     * @param componentDefiner The component definer, that will create the option fields.
+     */
+    static public JPanel create(@NotNull final Consumer<OptionsComponent> componentDefiner) {
+        // We should create a OptionsComponent that offer the features to create fields.
+        // Then the component definer will use that new instance to create them.
+        final OptionsComponent component = new OptionsComponent();
+        componentDefiner.accept(component);
+
+        // Returns only the JPanel component.
+        return component.optionsPanel;
+    }
+
+    /**
+     * Creates a Checkbox.
+     *
+     * @param fieldTitle     The title of the field on options panel.
+     * @param defaultValue   The default or current field value stored on inspection.
+     * @param updateConsumer The update consumer (called after item change).
+     */
+    public JCheckBox createCheckbox(final String fieldTitle, final boolean defaultValue, final Consumer<Boolean> updateConsumer) {
+        final JCheckBox createdCheckbox = new JCheckBox(fieldTitle, defaultValue);
+        createdCheckbox.addItemListener((itemEvent) -> updateConsumer.accept(createdCheckbox.isSelected()));
+
+        optionsPanel.add(createdCheckbox, "wrap");
+
+        return createdCheckbox;
+    }
+
+    /**
+     * Creates a new Radio component.
+     *
+     * @param componentDefiner The component definer, that will create the option radios.
+     */
+    public void createRadio(@NotNull final Consumer<RadioComponent> componentDefiner) {
+        final RadioComponent radioComponent = new RadioComponent();
+        componentDefiner.accept(radioComponent);
+    }
+
+    /**
+     * Creates a List.
+     *
+     * @param fieldTitle  The title of this field on panel.
+     * @param listItems   The default or current list items.
+     * @param listUpdater The event called after a modification on list items.
+     */
+    public void createList(final String fieldTitle, @NotNull final List<String> listItems, @NotNull final Runnable listUpdater) {
+        optionsPanel.add(new JLabel(fieldTitle), "wrap");
+        optionsPanel.add((new PrettyListControl(listItems) {
+            protected void fireContentsChanged() {
+                listUpdater.run();
+                super.fireContentsChanged();
+            }
+        }).getComponent(), "pushx, growx");
+    }
+
+    /**
+     * Create the checkboxes used as radios.
+     */
+    public class RadioComponent {
+        /**
+         * Store all Radio Elements handled by this Radio Component.
+         */
+        ArrayList<Element> elements = new ArrayList<>();
+
+        /**
+         * Store the current selected Radio.
+         */
+        @Nullable
+        private Element currentSelection;
+
+        /**
+         * @param fieldTitle     The title of the field on options panel.
+         * @param defaultValue   The default or current field value stored on inspection.
+         * @param updateConsumer The update consumer (called after item change).
+         */
+        public void createOption(final String fieldTitle, final boolean defaultValue, final Consumer<Boolean> updateConsumer) {
+            final Element createElement = new Element(fieldTitle, defaultValue, updateConsumer);
+            elements.add(createElement);
+
+            if (defaultValue) {
+                currentSelection = createElement;
+            }
+        }
+
+        /**
+         * Handle a JCheckBox component and it Update Consumer.
+         */
+        private class Element {
+            /**
+             * Stores the JCheckBox component related to the Element.
+             */
+            final JCheckBox checkbox;
+
+            /**
+             * Stores the Update Consumer related to the Element.
+             */
+            final Consumer<Boolean> updateConsumer;
+
+            /**
+             * Constructs the Element.
+             *
+             * @param fieldTitle     The title of the field on options panel.
+             * @param defaultValue   The default or current field value stored on inspection.
+             * @param updateConsumer The update consumer (called after item change).
+             */
+            Element(final String fieldTitle, final boolean defaultValue, final Consumer<Boolean> updateConsumer) {
+                this.updateConsumer = updateConsumer;
+
+                checkbox = new JCheckBox(fieldTitle, defaultValue);
+                checkbox.addItemListener((itemEvent) -> {
+                    final boolean isSelected = checkbox.isSelected();
+
+                    if (currentSelection != null && currentSelection != this) {
+                        currentSelection.setSelected(false);
+                    }
+
+                    updateConsumer.accept(isSelected);
+                    currentSelection = isSelected ? this : null;
+                });
+
+                optionsPanel.add(checkbox, "wrap");
+            }
+
+            final void setSelected(final boolean isSelected) {
+                checkbox.setSelected(isSelected);
+                updateConsumer.accept(isSelected);
+            }
+        }
+    }
+}

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/options/OptionsComponent.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/options/OptionsComponent.java
@@ -93,13 +93,13 @@ public class OptionsComponent {
         /**
          * Store all Radio Elements handled by this Radio Component.
          */
-        ArrayList<Element> elements = new ArrayList<>();
+        ArrayList<Widget> widgets = new ArrayList<>();
 
         /**
          * Store the current selected Radio.
          */
         @Nullable
-        private Element currentSelection;
+        private Widget currentSelection;
 
         /**
          * @param fieldTitle     The title of the field on options panel.
@@ -107,36 +107,36 @@ public class OptionsComponent {
          * @param updateConsumer The update consumer (called after item change).
          */
         public void createOption(final String fieldTitle, final boolean defaultValue, final Consumer<Boolean> updateConsumer) {
-            final Element createElement = new Element(fieldTitle, defaultValue, updateConsumer);
-            elements.add(createElement);
+            final Widget createWidget = new Widget(fieldTitle, defaultValue, updateConsumer);
+            widgets.add(createWidget);
 
             if (defaultValue) {
-                currentSelection = createElement;
+                currentSelection = createWidget;
             }
         }
 
         /**
          * Handle a JCheckBox component and it Update Consumer.
          */
-        private class Element {
+        private class Widget {
             /**
-             * Stores the JCheckBox component related to the Element.
+             * Stores the JCheckBox component related to the Widget.
              */
             final JCheckBox checkbox;
 
             /**
-             * Stores the Update Consumer related to the Element.
+             * Stores the Update Consumer related to the Widget.
              */
             final Consumer<Boolean> updateConsumer;
 
             /**
-             * Constructs the Element.
+             * Constructs the Widget.
              *
              * @param fieldTitle     The title of the field on options panel.
              * @param defaultValue   The default or current field value stored on inspection.
              * @param updateConsumer The update consumer (called after item change).
              */
-            Element(final String fieldTitle, final boolean defaultValue, final Consumer<Boolean> updateConsumer) {
+            Widget(final String fieldTitle, final boolean defaultValue, final Consumer<Boolean> updateConsumer) {
                 this.updateConsumer = updateConsumer;
 
                 checkbox = new JCheckBox(fieldTitle, defaultValue);
@@ -154,6 +154,11 @@ public class OptionsComponent {
                 optionsPanel.add(checkbox, "wrap");
             }
 
+            /**
+             * Update the checkbox "checked" status related to Widget and call the Consumer.
+             *
+             * @param isSelected Indicate the new status.
+             */
             final void setSelected(final boolean isSelected) {
                 checkbox.setSelected(isSelected);
                 updateConsumer.accept(isSelected);

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/api/IsEmptyFunctionUsageInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/api/IsEmptyFunctionUsageInspectorTest.java
@@ -7,9 +7,9 @@ import com.kalessil.phpStorm.phpInspectionsEA.inspectors.apiUsage.IsEmptyFunctio
 final public class IsEmptyFunctionUsageInspectorTest extends CodeInsightFixtureTestCase {
     public void testIfFindsAllPatterns() {
         final IsEmptyFunctionUsageInspector inspector = new IsEmptyFunctionUsageInspector();
-        inspector.optionSuggestToUseCountCheck = true;
-        inspector.optionReportEmptyUsage = true;
-        inspector.optionsToUseNullComparison = true;
+        inspector.SUGGEST_TO_USE_COUNT_CHECK = true;
+        inspector.REPORT_EMPTY_USAGE = true;
+        inspector.SUGGEST_TO_USE_NULL_COMPARISON = true;
 
         myFixture.configureByFile("fixtures/api/empty-function.php");
         myFixture.enableInspections(inspector);

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/api/IsEmptyFunctionUsageInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/api/IsEmptyFunctionUsageInspectorTest.java
@@ -7,9 +7,9 @@ import com.kalessil.phpStorm.phpInspectionsEA.inspectors.apiUsage.IsEmptyFunctio
 final public class IsEmptyFunctionUsageInspectorTest extends CodeInsightFixtureTestCase {
     public void testIfFindsAllPatterns() {
         final IsEmptyFunctionUsageInspector inspector = new IsEmptyFunctionUsageInspector();
-        inspector.SUGGEST_TO_USE_COUNT_CHECK          = true;
-        inspector.REPORT_EMPTY_USAGE                  = true;
-        inspector.SUGGEST_TO_USE_NULL_COMPARISON      = true;
+        inspector.optionSuggestToUseCountCheck = true;
+        inspector.optionReportEmptyUsage = true;
+        inspector.optionsToUseNullComparison = true;
 
         myFixture.configureByFile("fixtures/api/empty-function.php");
         myFixture.enableInspections(inspector);

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/api/RandomApiMigrationInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/api/RandomApiMigrationInspectorTest.java
@@ -8,7 +8,7 @@ import com.kalessil.phpStorm.phpInspectionsEA.inspectors.apiUsage.RandomApiMigra
 final public class RandomApiMigrationInspectorTest extends CodeInsightFixtureTestCase {
     public void testIfFindsMtPatterns() {
         RandomApiMigrationInspector inspector = new RandomApiMigrationInspector();
-        inspector.SUGGEST_USING_RANDOM_INT    = false;
+        inspector.optionSuggestUsingRandomInt = false;
 
         myFixture.configureByFile("fixtures/api/random-api-mt.php");
         myFixture.enableInspections(inspector);

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/api/RandomApiMigrationInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/api/RandomApiMigrationInspectorTest.java
@@ -8,7 +8,7 @@ import com.kalessil.phpStorm.phpInspectionsEA.inspectors.apiUsage.RandomApiMigra
 final public class RandomApiMigrationInspectorTest extends CodeInsightFixtureTestCase {
     public void testIfFindsMtPatterns() {
         RandomApiMigrationInspector inspector = new RandomApiMigrationInspector();
-        inspector.optionSuggestUsingRandomInt = false;
+        inspector.SUGGEST_USING_RANDOM_INT = false;
 
         myFixture.configureByFile("fixtures/api/random-api-mt.php");
         myFixture.enableInspections(inspector);

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/classes/SingletonFactoryPatternViolationInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/classes/SingletonFactoryPatternViolationInspectorTest.java
@@ -11,7 +11,7 @@ final public class SingletonFactoryPatternViolationInspectorTest extends CodeIns
     }
     public void testSingletonNeedsOverrideClone() {
         SingletonFactoryPatternViolationInspector inspector = new SingletonFactoryPatternViolationInspector();
-        inspector.SUGGEST_OVERRIDING_CLONE = true;
+        inspector.optionSuggestOverridingClone = true;
 
         myFixture.configureByFile("fixtures/designPatterns/singleton-needs-override-clone.php");
         myFixture.enableInspections(inspector);

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/classes/SingletonFactoryPatternViolationInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/classes/SingletonFactoryPatternViolationInspectorTest.java
@@ -11,7 +11,7 @@ final public class SingletonFactoryPatternViolationInspectorTest extends CodeIns
     }
     public void testSingletonNeedsOverrideClone() {
         SingletonFactoryPatternViolationInspector inspector = new SingletonFactoryPatternViolationInspector();
-        inspector.optionSuggestOverridingClone = true;
+        inspector.SUGGEST_OVERRIDING_CLONE = true;
 
         myFixture.configureByFile("fixtures/designPatterns/singleton-needs-override-clone.php");
         myFixture.enableInspections(inspector);

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/codeStyle/ComparisonOperandsOrderInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/codeStyle/ComparisonOperandsOrderInspectorTest.java
@@ -6,7 +6,7 @@ import com.kalessil.phpStorm.phpInspectionsEA.inspectors.codeSmell.ComparisonOpe
 final public class ComparisonOperandsOrderInspectorTest extends CodeInsightFixtureTestCase {
     public void testIfFindsYodaPatterns() {
         ComparisonOperandsOrderInspector inspector = new ComparisonOperandsOrderInspector();
-        inspector.optionPreferYodaStyle = true;
+        inspector.PREFER_YODA_STYLE = true;
 
         myFixture.configureByFile("fixtures/codeStyle/comparison-order-yoda.php");
         myFixture.enableInspections(inspector);
@@ -14,7 +14,7 @@ final public class ComparisonOperandsOrderInspectorTest extends CodeInsightFixtu
     }
     public void testIfFindsRegularPatterns() {
         ComparisonOperandsOrderInspector inspector = new ComparisonOperandsOrderInspector();
-        inspector.optionPreferRegularStyle = true;
+        inspector.PREFER_REGULAR_STYLE = true;
 
         myFixture.configureByFile("fixtures/codeStyle/comparison-order-regular.php");
         myFixture.enableInspections(inspector);

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/codeStyle/ComparisonOperandsOrderInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/codeStyle/ComparisonOperandsOrderInspectorTest.java
@@ -6,8 +6,7 @@ import com.kalessil.phpStorm.phpInspectionsEA.inspectors.codeSmell.ComparisonOpe
 final public class ComparisonOperandsOrderInspectorTest extends CodeInsightFixtureTestCase {
     public void testIfFindsYodaPatterns() {
         ComparisonOperandsOrderInspector inspector = new ComparisonOperandsOrderInspector();
-        inspector.CONFIGURED                       = true;
-        inspector.PREFER_YODA_STYLE                = true;
+        inspector.optionPreferYodaStyle = true;
 
         myFixture.configureByFile("fixtures/codeStyle/comparison-order-yoda.php");
         myFixture.enableInspections(inspector);
@@ -15,8 +14,7 @@ final public class ComparisonOperandsOrderInspectorTest extends CodeInsightFixtu
     }
     public void testIfFindsRegularPatterns() {
         ComparisonOperandsOrderInspector inspector = new ComparisonOperandsOrderInspector();
-        inspector.CONFIGURED                       = true;
-        inspector.PREFER_REGULAR_STYLE             = true;
+        inspector.optionPreferRegularStyle = true;
 
         myFixture.configureByFile("fixtures/codeStyle/comparison-order-regular.php");
         myFixture.enableInspections(inspector);

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/codeStyle/PropertyInitializationFlawsInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/codeStyle/PropertyInitializationFlawsInspectorTest.java
@@ -6,8 +6,8 @@ import com.kalessil.phpStorm.phpInspectionsEA.inspectors.apiUsage.PropertyInitia
 final public class PropertyInitializationFlawsInspectorTest extends CodeInsightFixtureTestCase {
     public void testNullInitPatterns() {
         PropertyInitializationFlawsInspector inspector = new PropertyInitializationFlawsInspector();
-        inspector.optionReportInitFlaws = true;
-        inspector.optionReportDefaultsFlaws = true;
+        inspector.REPORT_INIT_FLAWS = true;
+        inspector.REPORT_DEFAULTS_FLAWS = true;
 
         myFixture.configureByFile("fixtures/codeStyle/property-null-initialization.php");
         myFixture.enableInspections(inspector);
@@ -15,8 +15,8 @@ final public class PropertyInitializationFlawsInspectorTest extends CodeInsightF
     }
     public void testPropertyOverridePatterns() {
         PropertyInitializationFlawsInspector inspector = new PropertyInitializationFlawsInspector();
-        inspector.optionReportInitFlaws = true;
-        inspector.optionReportDefaultsFlaws = true;
+        inspector.REPORT_INIT_FLAWS = true;
+        inspector.REPORT_DEFAULTS_FLAWS = true;
 
         myFixture.configureByFile("fixtures/codeStyle/property-initialization-override.php");
         myFixture.enableInspections(inspector);

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/codeStyle/PropertyInitializationFlawsInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/codeStyle/PropertyInitializationFlawsInspectorTest.java
@@ -6,8 +6,8 @@ import com.kalessil.phpStorm.phpInspectionsEA.inspectors.apiUsage.PropertyInitia
 final public class PropertyInitializationFlawsInspectorTest extends CodeInsightFixtureTestCase {
     public void testNullInitPatterns() {
         PropertyInitializationFlawsInspector inspector = new PropertyInitializationFlawsInspector();
-        inspector.REPORT_INIT_FLAWS     = true;
-        inspector.REPORT_DEFAULTS_FLAWS = true;
+        inspector.optionReportInitFlaws = true;
+        inspector.optionReportDefaultsFlaws = true;
 
         myFixture.configureByFile("fixtures/codeStyle/property-null-initialization.php");
         myFixture.enableInspections(inspector);
@@ -15,8 +15,8 @@ final public class PropertyInitializationFlawsInspectorTest extends CodeInsightF
     }
     public void testPropertyOverridePatterns() {
         PropertyInitializationFlawsInspector inspector = new PropertyInitializationFlawsInspector();
-        inspector.REPORT_INIT_FLAWS     = true;
-        inspector.REPORT_DEFAULTS_FLAWS = true;
+        inspector.optionReportInitFlaws = true;
+        inspector.optionReportDefaultsFlaws = true;
 
         myFixture.configureByFile("fixtures/codeStyle/property-initialization-override.php");
         myFixture.enableInspections(inspector);

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/codeStyle/UsageOfSilenceOperatorInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/codeStyle/UsageOfSilenceOperatorInspectorTest.java
@@ -6,7 +6,7 @@ import com.kalessil.phpStorm.phpInspectionsEA.inspectors.codeSmell.UsageOfSilenc
 final public class UsageOfSilenceOperatorInspectorTest extends PhpCodeInsightFixtureTestCase {
     public void testIfFindsAllPatterns() {
         UsageOfSilenceOperatorInspector inspector = new UsageOfSilenceOperatorInspector();
-        inspector.RESPECT_CONTEXT                 = true;
+        inspector.optionRespectContext = true;
 
         myFixture.configureByFile("fixtures/codeStyle/usage-of-silence-operator.php");
         myFixture.enableInspections(inspector);

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/codeStyle/UsageOfSilenceOperatorInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/codeStyle/UsageOfSilenceOperatorInspectorTest.java
@@ -6,7 +6,7 @@ import com.kalessil.phpStorm.phpInspectionsEA.inspectors.codeSmell.UsageOfSilenc
 final public class UsageOfSilenceOperatorInspectorTest extends PhpCodeInsightFixtureTestCase {
     public void testIfFindsAllPatterns() {
         UsageOfSilenceOperatorInspector inspector = new UsageOfSilenceOperatorInspector();
-        inspector.optionRespectContext = true;
+        inspector.RESPECT_CONTEXT = true;
 
         myFixture.configureByFile("fixtures/codeStyle/usage-of-silence-operator.php");
         myFixture.enableInspections(inspector);

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/controlFlow/DisallowWritingIntoStaticPropertiesInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/controlFlow/DisallowWritingIntoStaticPropertiesInspectorTest.java
@@ -6,7 +6,7 @@ import com.kalessil.phpStorm.phpInspectionsEA.inspectors.codeSmell.DisallowWriti
 final public class DisallowWritingIntoStaticPropertiesInspectorTest extends CodeInsightFixtureTestCase {
     public void testAllowWriteFromSourceClassOnly() {
         DisallowWritingIntoStaticPropertiesInspector inspector = new DisallowWritingIntoStaticPropertiesInspector();
-        inspector.optionAllowWriteFromSourceClass = true;
+        inspector.ALLOW_WRITE_FROM_SOURCE_CLASS = true;
         myFixture.configureByFile("fixtures/controlFlow/disallow-write-into-static-property-default.php");
         myFixture.enableInspections(inspector);
         myFixture.testHighlighting(true, false, true);
@@ -14,7 +14,7 @@ final public class DisallowWritingIntoStaticPropertiesInspectorTest extends Code
 
     public void testDisallowAnyWrites() {
         DisallowWritingIntoStaticPropertiesInspector inspector = new DisallowWritingIntoStaticPropertiesInspector();
-        inspector.optionAllowWriteFromSourceClass = false;
+        inspector.ALLOW_WRITE_FROM_SOURCE_CLASS = false;
         myFixture.configureByFile("fixtures/controlFlow/disallow-any-write-into-static-property.php");
         myFixture.enableInspections(inspector);
         myFixture.testHighlighting(true, false, true);

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/controlFlow/DisallowWritingIntoStaticPropertiesInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/controlFlow/DisallowWritingIntoStaticPropertiesInspectorTest.java
@@ -6,7 +6,7 @@ import com.kalessil.phpStorm.phpInspectionsEA.inspectors.codeSmell.DisallowWriti
 final public class DisallowWritingIntoStaticPropertiesInspectorTest extends CodeInsightFixtureTestCase {
     public void testAllowWriteFromSourceClassOnly() {
         DisallowWritingIntoStaticPropertiesInspector inspector = new DisallowWritingIntoStaticPropertiesInspector();
-        inspector.ALLOW_WRITE_FROM_SOURCE_CLASS = true;
+        inspector.optionAllowWriteFromSourceClass = true;
         myFixture.configureByFile("fixtures/controlFlow/disallow-write-into-static-property-default.php");
         myFixture.enableInspections(inspector);
         myFixture.testHighlighting(true, false, true);
@@ -14,7 +14,7 @@ final public class DisallowWritingIntoStaticPropertiesInspectorTest extends Code
 
     public void testDisallowAnyWrites() {
         DisallowWritingIntoStaticPropertiesInspector inspector = new DisallowWritingIntoStaticPropertiesInspector();
-        inspector.ALLOW_WRITE_FROM_SOURCE_CLASS = false;
+        inspector.optionAllowWriteFromSourceClass = false;
         myFixture.configureByFile("fixtures/controlFlow/disallow-any-write-into-static-property.php");
         myFixture.enableInspections(inspector);
         myFixture.testHighlighting(true, false, true);

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/controlFlow/UnSafeIsSetOverArrayInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/controlFlow/UnSafeIsSetOverArrayInspectorTest.java
@@ -8,8 +8,8 @@ final public class UnSafeIsSetOverArrayInspectorTest extends CodeInsightFixtureT
     @NotNull
     private UnSafeIsSetOverArrayInspector getInspector() {
         UnSafeIsSetOverArrayInspector inspector = new UnSafeIsSetOverArrayInspector();
-        inspector.optionSuggestToUseArrayKeyExists = true;
-        inspector.optionSuggestToUseNullComparison = true;
+        inspector.SUGGEST_TO_USE_ARRAY_KEY_EXISTS = true;
+        inspector.SUGGEST_TO_USE_NULL_COMPARISON = true;
         return inspector;
     }
 

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/controlFlow/UnSafeIsSetOverArrayInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/controlFlow/UnSafeIsSetOverArrayInspectorTest.java
@@ -8,8 +8,8 @@ final public class UnSafeIsSetOverArrayInspectorTest extends CodeInsightFixtureT
     @NotNull
     private UnSafeIsSetOverArrayInspector getInspector() {
         UnSafeIsSetOverArrayInspector inspector = new UnSafeIsSetOverArrayInspector();
-        inspector.SUGGEST_TO_USE_ARRAY_KEY_EXISTS = true;
-        inspector.SUGGEST_TO_USE_NULL_COMPARISON  = true;
+        inspector.optionSuggestToUseArrayKeyExists = true;
+        inspector.optionSuggestToUseNullComparison = true;
         return inspector;
     }
 

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/foreach/AlterInForeachInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/foreach/AlterInForeachInspectorTest.java
@@ -6,7 +6,7 @@ import com.kalessil.phpStorm.phpInspectionsEA.inspectors.forEach.AlterInForeachI
 final public class AlterInForeachInspectorTest extends CodeInsightFixtureTestCase {
     public void testIfFindsAllPatterns() {
         AlterInForeachInspector inspector    = new AlterInForeachInspector();
-        inspector.optionSuggestUsingValueByRef = true;
+        inspector.SUGGEST_USING_VALUE_BY_REF = true;
 
         myFixture.configureByFile("fixtures/foreach/alter-in-foreach.php");
         myFixture.enableInspections(inspector);

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/foreach/AlterInForeachInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/foreach/AlterInForeachInspectorTest.java
@@ -6,7 +6,7 @@ import com.kalessil.phpStorm.phpInspectionsEA.inspectors.forEach.AlterInForeachI
 final public class AlterInForeachInspectorTest extends CodeInsightFixtureTestCase {
     public void testIfFindsAllPatterns() {
         AlterInForeachInspector inspector    = new AlterInForeachInspector();
-        inspector.SUGGEST_USING_VALUE_BY_REF = true;
+        inspector.optionSuggestUsingValueByRef = true;
 
         myFixture.configureByFile("fixtures/foreach/alter-in-foreach.php");
         myFixture.enableInspections(inspector);

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/foreach/DisconnectedForeachInstructionInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/foreach/DisconnectedForeachInstructionInspectorTest.java
@@ -6,7 +6,7 @@ import com.kalessil.phpStorm.phpInspectionsEA.inspectors.forEach.DisconnectedFor
 final public class DisconnectedForeachInstructionInspectorTest extends PhpCodeInsightFixtureTestCase {
     public void testIfFindsAllPatterns() {
         DisconnectedForeachInstructionInspector inspector = new DisconnectedForeachInstructionInspector();
-        inspector.optionSuggestUsingClone = true;
+        inspector.SUGGEST_USING_CLONE = true;
 
         myFixture.configureByFile("fixtures/foreach/disconnected-statements-foreach.php");
         myFixture.enableInspections(inspector);
@@ -15,7 +15,7 @@ final public class DisconnectedForeachInstructionInspectorTest extends PhpCodeIn
 
     public void testFalsePositives() {
         DisconnectedForeachInstructionInspector inspector = new DisconnectedForeachInstructionInspector();
-        inspector.optionSuggestUsingClone = true;
+        inspector.SUGGEST_USING_CLONE = true;
 
         myFixture.configureByFile("fixtures/foreach/disconnected-statements-foreach-false-positives.php");
         myFixture.enableInspections(inspector);

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/foreach/DisconnectedForeachInstructionInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/foreach/DisconnectedForeachInstructionInspectorTest.java
@@ -6,7 +6,7 @@ import com.kalessil.phpStorm.phpInspectionsEA.inspectors.forEach.DisconnectedFor
 final public class DisconnectedForeachInstructionInspectorTest extends PhpCodeInsightFixtureTestCase {
     public void testIfFindsAllPatterns() {
         DisconnectedForeachInstructionInspector inspector = new DisconnectedForeachInstructionInspector();
-        inspector.SUGGEST_USING_CLONE = true;
+        inspector.optionSuggestUsingClone = true;
 
         myFixture.configureByFile("fixtures/foreach/disconnected-statements-foreach.php");
         myFixture.enableInspections(inspector);
@@ -15,7 +15,7 @@ final public class DisconnectedForeachInstructionInspectorTest extends PhpCodeIn
 
     public void testFalsePositives() {
         DisconnectedForeachInstructionInspector inspector = new DisconnectedForeachInstructionInspector();
-        inspector.SUGGEST_USING_CLONE = true;
+        inspector.optionSuggestUsingClone = true;
 
         myFixture.configureByFile("fixtures/foreach/disconnected-statements-foreach-false-positives.php");
         myFixture.enableInspections(inspector);

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/ifs/NotOptimalIfConditionsInspectionTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/ifs/NotOptimalIfConditionsInspectionTest.java
@@ -21,7 +21,7 @@ final public class NotOptimalIfConditionsInspectionTest extends CodeInsightFixtu
     }
     public void testLiteralOperatorsPatterns() {
         NotOptimalIfConditionsInspection inspector = new NotOptimalIfConditionsInspection();
-        inspector.REPORT_LITERAL_OPERATORS         = true;
+        inspector.optionReportLiteralOperators = true;
 
         myFixture.configureByFile("fixtures/ifs/if-literal-operators.php");
         myFixture.enableInspections(inspector);

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/ifs/NotOptimalIfConditionsInspectionTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/ifs/NotOptimalIfConditionsInspectionTest.java
@@ -21,7 +21,7 @@ final public class NotOptimalIfConditionsInspectionTest extends CodeInsightFixtu
     }
     public void testLiteralOperatorsPatterns() {
         NotOptimalIfConditionsInspection inspector = new NotOptimalIfConditionsInspection();
-        inspector.optionReportLiteralOperators = true;
+        inspector.REPORT_LITERAL_OPERATORS = true;
 
         myFixture.configureByFile("fixtures/ifs/if-literal-operators.php");
         myFixture.enableInspections(inspector);

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/lang/ClassConstantCanBeUsedInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/lang/ClassConstantCanBeUsedInspectorTest.java
@@ -7,9 +7,9 @@ import com.kalessil.phpStorm.phpInspectionsEA.inspectors.languageConstructions.C
 final public class ClassConstantCanBeUsedInspectorTest extends PhpCodeInsightFixtureTestCase {
     public void testIfFindsAllPatterns() {
         ClassConstantCanBeUsedInspector inspector = new ClassConstantCanBeUsedInspector();
-        inspector.optionImportClassesOnQF = true;
-        inspector.optionUseRelativeQF = true;
-        inspector.optionLookRootNsUp = true;
+        inspector.IMPORT_CLASSES_ON_QF = true;
+        inspector.USE_RELATIVE_QF = true;
+        inspector.LOOK_ROOT_NS_UP = true;
 
         myFixture.configureByFile("fixtures/lang/classConstant/class-in-the-same-namespace.php");
         myFixture.configureByFile("fixtures/lang/classConstant/class-name-constant-ns.php");

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/lang/ClassConstantCanBeUsedInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/lang/ClassConstantCanBeUsedInspectorTest.java
@@ -7,9 +7,9 @@ import com.kalessil.phpStorm.phpInspectionsEA.inspectors.languageConstructions.C
 final public class ClassConstantCanBeUsedInspectorTest extends PhpCodeInsightFixtureTestCase {
     public void testIfFindsAllPatterns() {
         ClassConstantCanBeUsedInspector inspector = new ClassConstantCanBeUsedInspector();
-        inspector.IMPORT_CLASSES_ON_QF            = true;
-        inspector.USE_RELATIVE_QF                 = true;
-        inspector.LOOK_ROOT_NS_UP                 = true;
+        inspector.optionImportClassesOnQF = true;
+        inspector.optionUseRelativeQF = true;
+        inspector.optionLookRootNsUp = true;
 
         myFixture.configureByFile("fixtures/lang/classConstant/class-in-the-same-namespace.php");
         myFixture.configureByFile("fixtures/lang/classConstant/class-name-constant-ns.php");

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/magicMethods/ImplicitMagicMethodCallInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/magicMethods/ImplicitMagicMethodCallInspectorTest.java
@@ -6,7 +6,7 @@ import com.kalessil.phpStorm.phpInspectionsEA.inspectors.magicMethods.ImplicitMa
 final public class ImplicitMagicMethodCallInspectorTest extends CodeInsightFixtureTestCase {
     public void testIfFindsAllPatterns() {
         ImplicitMagicMethodCallInspector inspector = new ImplicitMagicMethodCallInspector();
-        inspector.SUGGEST_USING_STRING_CASTING = true;
+        inspector.optionSuggestUsingStringCasting = true;
 
         myFixture.configureByFile("fixtures/magicMethods/magic-methods-implicit-call.php");
         myFixture.enableInspections(inspector);

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/magicMethods/ImplicitMagicMethodCallInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/magicMethods/ImplicitMagicMethodCallInspectorTest.java
@@ -6,7 +6,7 @@ import com.kalessil.phpStorm.phpInspectionsEA.inspectors.magicMethods.ImplicitMa
 final public class ImplicitMagicMethodCallInspectorTest extends CodeInsightFixtureTestCase {
     public void testIfFindsAllPatterns() {
         ImplicitMagicMethodCallInspector inspector = new ImplicitMagicMethodCallInspector();
-        inspector.optionSuggestUsingStringCasting = true;
+        inspector.SUGGEST_USING_STRING_CASTING = true;
 
         myFixture.configureByFile("fixtures/magicMethods/magic-methods-implicit-call.php");
         myFixture.enableInspections(inspector);


### PR DESCRIPTION
_Okay, it modifies 33 files by a good reason: **readability**.
Future devs will appreciate it a lot._

Following #277, I did this changes to optimize the `JComponent`'s creation on inspections that declares it. It is inevitably part of the inspection class, generated by method `createOptionsPanel()`.

Basically I have create a new class called `OptionsComponent` that can handle tree types of components: _checkboxes_ (via `createCheckbox()`), _radios buttons_ (via `createRadio()`) and _lists_ (via `createList()`).

~~As exception (_included on original code_), the _radio buttons_ is treated like _checkboxes_. It happen only on inspection "_yoda/regular conditions style usage_", and in this case, we need have the possibility to disable this inspection by unchecking both options (_yoda_ and _regular style_). We can create real radio buttons here instead (via `JRadioButton`), but I don't think need and checkbox works for now.~~ Fixed/waiting for #288.

~~Another change that I have did was rename all fields that is treated like an option. Then instead it seems like an static variable (like `SUGGEST_TO_USE_COUNT_CHECK`) now it is treated like an option variable (like `optionSuggestToUseCountCheck`).~~ Reverted to avoid BC (will be discussed later).

In general, it have reduced the code related to inspection options from about 260 lines to 45 (excluding spaces). Which is a reduction of 83%, which means that I will pay less when do a new eye exam. It mean that a lot of duplicate/similar code and needless inner classes was dropped too.

_Well, the next step is do a similar thing with UTs._