### PR TITLE
[#293] Detect magic numbers

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -653,6 +653,10 @@ with a laptop.
         shortName="MisorderedModifiersInspection"                 displayName="PSR-compliant modifiers order"
         groupName="Code Style"                                    enabledByDefault="true" level="WEAK WARNING"
         implementationClass="com.kalessil.phpStorm.phpInspectionsEA.inspectors.codeSmell.MisorderedModifiersInspector"/>
+    <localInspection language="PHP" groupPath="PHP,Php Inspections (EA Extended)"
+        shortName="MagicNumberInspection"                         displayName="Magic number usage"
+        groupName="Code Style"                                    enabledByDefault="true" level="WEAK WARNING"
+        implementationClass="com.kalessil.phpStorm.phpInspectionsEA.inspectors.codeSmell.MagicNumberInspector"/>
 
 
     <localInspection language="PHP" groupPath="PHP,Php Inspections (EA Extended)"

--- a/RULES.md
+++ b/RULES.md
@@ -109,6 +109,7 @@ Inspections Lists (Code style)
 | Code style           | UnknownInspectionInspection                     | Unknown inspection suppression                      | n/a | yes | n/a  | no  |
 | Code style           | ParameterDefaultValueIsNotNullInspection        | Non-null parameters default value                   | n/a | yes | n/a  | yes |
 | Code style           | MisorderedModifiersInspection                   | PSR-compliant modifiers order                       | yes | yes | yes  | no  |
+| Code style           | MagicNumberInspection                           | Magic number usage                                  | no  | yes | no   | no  |
 
 Inspections Lists (Language level migration)
 ---

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
@@ -32,7 +32,6 @@ import com.kalessil.phpStorm.phpInspectionsEA.utils.ElementTypeUtil;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 
 import javax.swing.*;
 
@@ -75,7 +74,7 @@ public class MagicNumberInspector extends BasePhpInspection {
                     return;
                 }
 
-                if (Objects.equals(expression.getOperationType(), PhpTokenTypes.opMUL_ASGN)) {
+                if (expression.getOperationType() == PhpTokenTypes.opMUL_ASGN) {
                     final PhpPsiElement expressionValue = expression.getValue();
 
                     if (isNumberOneNegative(expressionValue)) {
@@ -117,7 +116,7 @@ public class MagicNumberInspector extends BasePhpInspection {
 
             @Override
             public void visitPhpBinaryExpression(final BinaryExpression expression) {
-                if (Objects.equals(expression.getOperationType(), PhpTokenTypes.opMUL)) {
+                if (expression.getOperationType() == PhpTokenTypes.opMUL) {
                     if (!optionCheckOnMultiplier) {
                         return;
                     }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
@@ -68,8 +68,14 @@ public class MagicNumberInspector extends BasePhpInspection {
             }
 
             private boolean isNumeric(final PsiElement expression) {
-                return (expression instanceof PhpExpressionImpl) &&
-                       (expression.getNode().getElementType() == PhpElementTypes.NUMBER);
+                PsiElement testingExpression = expression;
+
+                if (testingExpression instanceof UnaryExpression) {
+                    testingExpression = ((UnaryExpression) testingExpression).getValue();
+                }
+
+                return (testingExpression instanceof PhpExpressionImpl) &&
+                       (testingExpression.getNode().getElementType() == PhpElementTypes.NUMBER);
             }
 
             private boolean isCounting(@NotNull final BinaryExpression binaryExpression) {

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
@@ -1,0 +1,44 @@
+package com.kalessil.phpStorm.phpInspectionsEA.inspectors.codeSmell;
+
+import com.intellij.codeInspection.ProblemHighlightType;
+import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.psi.PsiElementVisitor;
+import com.jetbrains.php.lang.psi.elements.PhpExpression;
+import com.jetbrains.php.lang.psi.resolve.types.PhpType;
+import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
+import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.jetbrains.annotations.NotNull;
+
+public class MagicNumberInspector extends BasePhpInspection {
+    private static final String message = "Magic number should be replaced by a constant.";
+
+    private static final Collection<String> allowedNumbers = new ArrayList<>();
+
+    static {
+        allowedNumbers.add("0");
+        allowedNumbers.add("1");
+    }
+
+    @NotNull
+    public String getShortName() {
+        return "MagicNumberInspection";
+    }
+
+    @Override
+    @NotNull
+    public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder problemsHolder, final boolean isOnTheFly) {
+        return new BasePhpElementVisitor() {
+            @Override
+            public void visitPhpExpression(final PhpExpression expression) {
+                if (!PhpType.FLOAT_INT.filter(expression.getType()).isEmpty() &&
+                    !allowedNumbers.contains(expression.getText())) {
+                    problemsHolder.registerProblem(expression, message, ProblemHighlightType.WEAK_WARNING);
+                }
+            }
+        };
+    }
+}

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
@@ -154,7 +154,7 @@ public class MagicNumberInspector extends BasePhpInspection {
                     operationType.equals(PhpTokenTypes.opNOT_IDENTICAL) ||
                     operationType.equals(PhpTokenTypes.opEQUAL) ||
                     operationType.equals(PhpTokenTypes.opNOT_EQUAL)) {
-                    return isBinaryNumeric(numericOperand.getText());
+                    return "0".equals(numericOperand.getText());
                 }
 
                 final IElementType normalizeOperationType = numericOnOpposite ? operationType : ElementTypeUtil.rotateOperation(operationType);

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
@@ -6,6 +6,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.jetbrains.php.lang.parser.PhpElementTypes;
 import com.jetbrains.php.lang.psi.elements.BinaryExpression;
+import com.jetbrains.php.lang.psi.elements.FunctionReference;
 import com.jetbrains.php.lang.psi.elements.PhpExpression;
 import com.jetbrains.php.lang.psi.elements.PhpReturn;
 import com.jetbrains.php.lang.psi.elements.impl.PhpExpressionImpl;
@@ -44,18 +45,28 @@ public class MagicNumberInspector extends BasePhpInspection {
                     return;
                 }
 
-                if (isNumeric(expression.getLeftOperand())) {
-                    registerProblem(expression.getLeftOperand());
+                final PsiElement leftOperand  = expression.getLeftOperand();
+                final PsiElement rightOperand = expression.getRightOperand();
+
+                if (isNumeric(leftOperand) &&
+                    !isZeroComparedToFunctionReference(leftOperand, rightOperand)) {
+                    registerProblem(leftOperand);
                 }
 
-                if (isNumeric(expression.getRightOperand())) {
-                    registerProblem(expression.getRightOperand());
+                if (isNumeric(rightOperand) &&
+                    !isZeroComparedToFunctionReference(rightOperand, leftOperand)) {
+                    registerProblem(rightOperand);
                 }
             }
 
             private boolean isNumeric(final PsiElement expression) {
                 return (expression instanceof PhpExpressionImpl) &&
                        (expression.getNode().getElementType() == PhpElementTypes.NUMBER);
+            }
+
+            private boolean isZeroComparedToFunctionReference(@NotNull final PsiElement primaryOperand, final PsiElement oppositeOperand) {
+                return "0".equals(primaryOperand.getText()) &&
+                       (oppositeOperand instanceof FunctionReference);
             }
 
             private void registerProblem(final PsiElement rightOperand) {

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
@@ -34,7 +34,7 @@ public class MagicNumberInspector extends BasePhpInspection {
         return new BasePhpElementVisitor() {
             @Override
             public void visitPhpExpression(final PhpExpression expression) {
-                if (!PhpType.FLOAT_INT.filter(expression.getType()).isEmpty() &&
+                if (PhpType.intersects(expression.getType(), PhpType.FLOAT_INT) &&
                     !allowedNumbers.contains(expression.getText())) {
                     problemsHolder.registerProblem(expression, message, ProblemHighlightType.WEAK_WARNING);
                 }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
@@ -67,6 +67,22 @@ public class MagicNumberInspector extends BasePhpInspection {
                 }
             }
 
+            @Override
+            public void visitPhpField(final Field field) {
+                if (!field.isConstant()) {
+                    final PsiElement fieldValue = field.getDefaultValue();
+
+                    if (fieldValue == null) {
+                        return;
+                    }
+
+                    if (isNumeric(fieldValue) &&
+                        !"0".equals(fieldValue.getText())) {
+                        registerProblem(fieldValue);
+                    }
+                }
+            }
+
             private boolean isNumeric(final PsiElement expression) {
                 PsiElement testingExpression = expression;
 

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
@@ -43,13 +43,11 @@ public class MagicNumberInspector extends BasePhpInspection {
     public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder problemsHolder, final boolean isOnTheFly) {
         return new BasePhpElementVisitor() {
             @Override
-            public void visitPhpExpression(final PhpExpression expression) {
-                if (isNumeric(expression)) {
-                    if (!(expression.getParent() instanceof PhpReturn)) {
-                        return;
-                    }
+            public void visitPhpReturn(final PhpReturn returnStatement) {
+                final PsiElement returnArgument = returnStatement.getArgument();
 
-                    registerProblem(expression);
+                if (isNumeric(returnArgument)) {
+                    registerProblem(returnArgument);
                 }
             }
 

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
@@ -4,6 +4,7 @@ import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.psi.PsiElementVisitor;
 import com.jetbrains.php.lang.psi.elements.PhpExpression;
+import com.jetbrains.php.lang.psi.elements.PhpReturn;
 import com.jetbrains.php.lang.psi.resolve.types.PhpType;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
@@ -36,6 +37,10 @@ public class MagicNumberInspector extends BasePhpInspection {
             public void visitPhpExpression(final PhpExpression expression) {
                 if (PhpType.intersects(expression.getType(), PhpType.FLOAT_INT) &&
                     !allowedNumbers.contains(expression.getText())) {
+                    if (!(expression.getParent() instanceof PhpReturn)) {
+                        return;
+                    }
+
                     problemsHolder.registerProblem(expression, message, ProblemHighlightType.WEAK_WARNING);
                 }
             }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
@@ -9,20 +9,10 @@ import com.jetbrains.php.lang.psi.resolve.types.PhpType;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
 
-import java.util.ArrayList;
-import java.util.Collection;
-
 import org.jetbrains.annotations.NotNull;
 
 public class MagicNumberInspector extends BasePhpInspection {
     private static final String message = "Magic number should be replaced by a constant.";
-
-    private static final Collection<String> allowedNumbers = new ArrayList<>();
-
-    static {
-        allowedNumbers.add("0");
-        allowedNumbers.add("1");
-    }
 
     @NotNull
     public String getShortName() {
@@ -35,8 +25,7 @@ public class MagicNumberInspector extends BasePhpInspection {
         return new BasePhpElementVisitor() {
             @Override
             public void visitPhpExpression(final PhpExpression expression) {
-                if (PhpType.intersects(expression.getType(), PhpType.FLOAT_INT) &&
-                    !allowedNumbers.contains(expression.getText())) {
+                if (PhpType.intersects(expression.getType(), PhpType.FLOAT_INT)) {
                     if (!(expression.getParent() instanceof PhpReturn)) {
                         return;
                     }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
@@ -5,10 +5,7 @@ import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.jetbrains.php.lang.parser.PhpElementTypes;
-import com.jetbrains.php.lang.psi.elements.BinaryExpression;
-import com.jetbrains.php.lang.psi.elements.FunctionReference;
-import com.jetbrains.php.lang.psi.elements.PhpExpression;
-import com.jetbrains.php.lang.psi.elements.PhpReturn;
+import com.jetbrains.php.lang.psi.elements.*;
 import com.jetbrains.php.lang.psi.elements.impl.PhpExpressionImpl;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
@@ -56,6 +53,17 @@ public class MagicNumberInspector extends BasePhpInspection {
                 if (isNumeric(rightOperand) &&
                     !isZeroComparedToFunctionReference(rightOperand, leftOperand)) {
                     registerProblem(rightOperand);
+                }
+            }
+
+            @Override
+            public void visitPhpSwitch(final PhpSwitch switchStatement) {
+                for (final PhpCase switchCase : switchStatement.getCases()) {
+                    final PhpPsiElement caseCondition = switchCase.getCondition();
+
+                    if (isNumeric(caseCondition)) {
+                        registerProblem(caseCondition);
+                    }
                 }
             }
 

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
@@ -17,6 +17,7 @@ import com.kalessil.phpStorm.phpInspectionsEA.utils.ElementTypeUtil;
 import java.util.Objects;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class MagicNumberInspector extends BasePhpInspection {
     private static final String message = "Magic number should be replaced by a constant.";
@@ -85,17 +86,16 @@ public class MagicNumberInspector extends BasePhpInspection {
 
             @Override
             public void visitPhpField(final Field field) {
-                if (!field.isConstant()) {
-                    final PsiElement fieldValue = field.getDefaultValue();
+                if (!field.isConstant() &&
+                    isNotZeroNumber(field.getDefaultValue())) {
+                    registerProblem(field.getDefaultValue());
+                }
+            }
 
-                    if (fieldValue == null) {
-                        return;
-                    }
-
-                    if (isNumeric(fieldValue) &&
-                        !"0".equals(fieldValue.getText())) {
-                        registerProblem(fieldValue);
-                    }
+            @Override
+            public void visitPhpParameter(final Parameter parameter) {
+                if (isNotZeroNumber(parameter.getDefaultValue())) {
+                    registerProblem(parameter.getDefaultValue());
                 }
             }
 
@@ -123,6 +123,12 @@ public class MagicNumberInspector extends BasePhpInspection {
 
                 return (testingExpression instanceof PhpExpressionImpl) &&
                        (testingExpression.getNode().getElementType() == PhpElementTypes.NUMBER);
+            }
+
+            private boolean isNotZeroNumber(@Nullable final PsiElement value) {
+                return (value != null) &&
+                       isNumeric(value) &&
+                       !"0".equals(value.getText());
             }
 
             private boolean isNumberOneNegative(final PsiElement unaryExpression) {

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
@@ -134,7 +134,7 @@ public class MagicNumberInspector extends BasePhpInspection {
 
                 if (function == null) {
                     for (final PsiElement referenceParameter : functionReference.getParameters()) {
-                        if (isNumeric(referenceParameter)) {
+                        if (isNotZeroNumber(referenceParameter)) {
                             registerProblem(referenceParameter);
                         }
                     }
@@ -150,14 +150,9 @@ public class MagicNumberInspector extends BasePhpInspection {
                 for (int parameterIndex = 0; parameterIndex < referenceParametersSize; parameterIndex++) {
                     final PsiElement referenceParameter = referenceParameters.get(parameterIndex);
 
-                    if (isNumeric(referenceParameter)) {
+                    if (isNotZeroNumber(referenceParameter)) {
                         if (parameterIndex <= functionParametersLimit) {
                             final Parameter functionParameter = functionParameters.get(parameterIndex);
-
-                            if ("0".equals(referenceParameter.getText()) &&
-                                PhpType.intersects(functionParameter.getType(), PhpType.INT)) {
-                                continue;
-                            }
 
                             if (isDefaultValued(functionParameter, referenceParameter)) {
                                 continue;

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
@@ -4,11 +4,11 @@ import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
+import com.jetbrains.php.lang.parser.PhpElementTypes;
 import com.jetbrains.php.lang.psi.elements.BinaryExpression;
 import com.jetbrains.php.lang.psi.elements.PhpExpression;
 import com.jetbrains.php.lang.psi.elements.PhpReturn;
-import com.jetbrains.php.lang.psi.elements.PhpTypedElement;
-import com.jetbrains.php.lang.psi.resolve.types.PhpType;
+import com.jetbrains.php.lang.psi.elements.impl.PhpExpressionImpl;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.BinaryExpressionUtil;
@@ -40,7 +40,7 @@ public class MagicNumberInspector extends BasePhpInspection {
 
             @Override
             public void visitPhpBinaryExpression(final BinaryExpression expression) {
-                if(!BinaryExpressionUtil.isComparison(expression)) {
+                if (!BinaryExpressionUtil.isComparison(expression)) {
                     return;
                 }
 
@@ -54,8 +54,8 @@ public class MagicNumberInspector extends BasePhpInspection {
             }
 
             private boolean isNumeric(final PsiElement expression) {
-                return (expression instanceof PhpTypedElement) &&
-                       PhpType.intersects(((PhpTypedElement) expression).getType(), PhpType.FLOAT_INT);
+                return (expression instanceof PhpExpressionImpl) &&
+                       (expression.getNode().getElementType() == PhpElementTypes.NUMBER);
             }
 
             private void registerProblem(final PsiElement rightOperand) {

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
@@ -168,22 +168,28 @@ public class MagicNumberInspector extends BasePhpInspection {
 
             private boolean isDefaultValued(@Nullable final Parameter functionParameter, final PsiElement referenceParameter) {
                 if (functionParameter != null) {
-                    PsiElement defaultOriginal = functionParameter.getDefaultValue();
+                    PsiElement defaultValue = functionParameter.getDefaultValue();
 
-                    if (defaultOriginal == null) {
+                    if (defaultValue == null) {
                         return false;
                     }
 
-                    while (defaultOriginal instanceof ConstantReference) {
-                        final PsiElement nextReference = ((PsiReference) defaultOriginal).resolve();
+                    while (defaultValue instanceof ConstantReference) {
+                        final PsiElement nextReference = ((PsiReference) defaultValue).resolve();
 
                         if (nextReference instanceof Constant) {
-                            defaultOriginal = ((Constant) nextReference).getValue();
+                            final PsiElement nextReferenceValue = ((Constant) nextReference).getValue();
+
+                            if (defaultValue == nextReferenceValue) {
+                                return false;
+                            }
+
+                            defaultValue = nextReferenceValue;
                         }
                     }
 
-                    return (defaultOriginal != null) &&
-                           defaultOriginal.getText().equals(referenceParameter.getText());
+                    return (defaultValue != null) &&
+                           defaultValue.getText().equals(referenceParameter.getText());
                 }
 
                 return false;

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
@@ -143,6 +143,7 @@ public class MagicNumberInspector extends BasePhpInspection {
                 }
 
                 final List<Parameter>  functionParameters      = new ArrayList<>(Arrays.asList(function.getParameters()));
+                final int              functionParametersLimit = functionParameters.size() - 1;
                 final List<PsiElement> referenceParameters     = new ArrayList<>(Arrays.asList(functionReference.getParameters()));
                 final int              referenceParametersSize = referenceParameters.size();
 
@@ -150,15 +151,17 @@ public class MagicNumberInspector extends BasePhpInspection {
                     final PsiElement referenceParameter = referenceParameters.get(parameterIndex);
 
                     if (isNumeric(referenceParameter)) {
-                        final Parameter functionParameter = functionParameters.get(parameterIndex);
+                        if (parameterIndex <= functionParametersLimit) {
+                            final Parameter functionParameter = functionParameters.get(parameterIndex);
 
-                        if ("0".equals(referenceParameter.getText()) &&
-                            PhpType.intersects(functionParameter.getType(), PhpType.INT)) {
-                            continue;
-                        }
+                            if ("0".equals(referenceParameter.getText()) &&
+                                PhpType.intersects(functionParameter.getType(), PhpType.INT)) {
+                                continue;
+                            }
 
-                        if (isDefaultValued(functionParameter, referenceParameter)) {
-                            continue;
+                            if (isDefaultValued(functionParameter, referenceParameter)) {
+                                continue;
+                            }
                         }
 
                         registerProblem(referenceParameter);

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
@@ -42,10 +42,11 @@ import org.jetbrains.annotations.Nullable;
 public class MagicNumberInspector extends BasePhpInspection {
     private static final String message = "Magic number should be replaced by a constant.";
 
-    boolean optionCheckOnMultiplier = true;
-    boolean optionCheckOnProperties = true;
-    boolean optionCheckOnParameters = true;
-    boolean optionCheckOnArguments  = true;
+    // Inspection options.
+    @SuppressWarnings ("WeakerAccess") public boolean optionCheckOnMultiplier = true;
+    @SuppressWarnings ("WeakerAccess") public boolean optionCheckOnProperties = true;
+    @SuppressWarnings ("WeakerAccess") public boolean optionCheckOnParameters = true;
+    @SuppressWarnings ("WeakerAccess") public boolean optionCheckOnArguments  = true;
 
     @NotNull
     public String getShortName() {
@@ -231,7 +232,11 @@ public class MagicNumberInspector extends BasePhpInspection {
                 return false;
             }
 
-            private boolean isNumeric(final PsiElement expression) {
+            private boolean isNumeric(@Nullable final PsiElement expression) {
+                if (expression == null) {
+                    return false;
+                }
+
                 PsiElement testingExpression = expression;
 
                 if (testingExpression instanceof UnaryExpression) {
@@ -248,7 +253,7 @@ public class MagicNumberInspector extends BasePhpInspection {
                        !"0".equals(value.getText());
             }
 
-            private boolean isNumberOneNegative(final PsiElement unaryExpression) {
+            private boolean isNumberOneNegative(@Nullable final PsiElement unaryExpression) {
                 if (!(unaryExpression instanceof UnaryExpression)) {
                     return false;
                 }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspector.java
@@ -10,6 +10,7 @@ import com.jetbrains.php.lang.lexer.PhpTokenTypes;
 import com.jetbrains.php.lang.parser.PhpElementTypes;
 import com.jetbrains.php.lang.psi.elements.*;
 import com.jetbrains.php.lang.psi.elements.impl.PhpExpressionImpl;
+import com.jetbrains.php.lang.psi.resolve.types.PhpType;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.BinaryExpressionUtil;
@@ -150,6 +151,11 @@ public class MagicNumberInspector extends BasePhpInspection {
 
                     if (isNumeric(referenceParameter)) {
                         final Parameter functionParameter = functionParameters.get(parameterIndex);
+
+                        if ("0".equals(referenceParameter.getText()) &&
+                            PhpType.intersects(functionParameter.getType(), PhpType.INT)) {
+                            continue;
+                        }
 
                         if (isDefaultValued(functionParameter, referenceParameter)) {
                             continue;

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/binaryOperations/strategy/IdenticalOperandsStrategy.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/binaryOperations/strategy/IdenticalOperandsStrategy.java
@@ -4,14 +4,11 @@ import com.intellij.codeInsight.PsiEquivalenceUtil;
 import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.psi.PsiElement;
-import com.intellij.psi.tree.IElementType;
-import com.jetbrains.php.lang.lexer.PhpTokenTypes;
 import com.jetbrains.php.lang.psi.elements.BinaryExpression;
+import com.kalessil.phpStorm.phpInspectionsEA.utils.BinaryExpressionUtil;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.ExpressionSemanticUtil;
-import org.jetbrains.annotations.NotNull;
 
-import java.util.HashSet;
-import java.util.Set;
+import org.jetbrains.annotations.NotNull;
 
 /*
  * This file is part of the Php Inspections (EA Extended) package.
@@ -25,19 +22,6 @@ import java.util.Set;
 final public class IdenticalOperandsStrategy {
     private static final String message = "Left and right operands are identical.";
 
-    private final static Set<IElementType> operationsToCheck = new HashSet<>();
-    static {
-        operationsToCheck.add(PhpTokenTypes.opEQUAL);
-        operationsToCheck.add(PhpTokenTypes.opIDENTICAL);
-        operationsToCheck.add(PhpTokenTypes.opNOT_EQUAL);
-        operationsToCheck.add(PhpTokenTypes.opNOT_IDENTICAL);
-        operationsToCheck.add(PhpTokenTypes.opGREATER);
-        operationsToCheck.add(PhpTokenTypes.opGREATER_OR_EQUAL);
-        operationsToCheck.add(PhpTokenTypes.opLESS);
-        operationsToCheck.add(PhpTokenTypes.opLESS_OR_EQUAL);
-        operationsToCheck.add(PhpTokenTypes.kwINSTANCEOF);
-    }
-
     public static boolean apply(@NotNull BinaryExpression expression, @NotNull ProblemsHolder holder) {
         final PsiElement left  = ExpressionSemanticUtil.getExpressionTroughParenthesis(expression.getLeftOperand());
         final PsiElement right = ExpressionSemanticUtil.getExpressionTroughParenthesis(expression.getRightOperand());
@@ -45,8 +29,7 @@ final public class IdenticalOperandsStrategy {
             return false;
         }
 
-        final IElementType operation = expression.getOperationType();
-        if (operationsToCheck.contains(operation) && PsiEquivalenceUtil.areElementsEquivalent(left, right)) {
+        if (BinaryExpressionUtil.isComparison(expression) && PsiEquivalenceUtil.areElementsEquivalent(left, right)) {
             holder.registerProblem(expression, message, ProblemHighlightType.GENERIC_ERROR);
             return true;
         }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/utils/BinaryExpressionUtil.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/utils/BinaryExpressionUtil.java
@@ -1,0 +1,32 @@
+package com.kalessil.phpStorm.phpInspectionsEA.utils;
+
+import com.intellij.psi.tree.IElementType;
+import com.jetbrains.php.lang.lexer.PhpTokenTypes;
+import com.jetbrains.php.lang.psi.elements.BinaryExpression;
+
+import java.util.Collection;
+import java.util.HashSet;
+
+import org.jetbrains.annotations.NotNull;
+
+public enum BinaryExpressionUtil {
+    ;
+
+    private static final Collection<IElementType> operationTypes = new HashSet<>();
+
+    static {
+        operationTypes.add(PhpTokenTypes.opEQUAL);
+        operationTypes.add(PhpTokenTypes.opIDENTICAL);
+        operationTypes.add(PhpTokenTypes.opNOT_EQUAL);
+        operationTypes.add(PhpTokenTypes.opNOT_IDENTICAL);
+        operationTypes.add(PhpTokenTypes.opGREATER);
+        operationTypes.add(PhpTokenTypes.opGREATER_OR_EQUAL);
+        operationTypes.add(PhpTokenTypes.opLESS);
+        operationTypes.add(PhpTokenTypes.opLESS_OR_EQUAL);
+        operationTypes.add(PhpTokenTypes.kwINSTANCEOF);
+    }
+
+    public static boolean isComparison(@NotNull final BinaryExpression binaryExpression) {
+        return operationTypes.contains(binaryExpression.getOperationType());
+    }
+}

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/utils/ElementTypeUtil.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/utils/ElementTypeUtil.java
@@ -1,0 +1,28 @@
+package com.kalessil.phpStorm.phpInspectionsEA.utils;
+
+import com.intellij.psi.tree.IElementType;
+import com.jetbrains.php.lang.lexer.PhpTokenTypes;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum ElementTypeUtil {
+    ;
+
+    private static final Map<IElementType, IElementType> reverseTypes = new HashMap<>();
+
+    static {
+        reverseTypes.put(PhpTokenTypes.opGREATER, PhpTokenTypes.opLESS_OR_EQUAL);
+        reverseTypes.put(PhpTokenTypes.opGREATER_OR_EQUAL, PhpTokenTypes.opLESS);
+        reverseTypes.put(PhpTokenTypes.opLESS, PhpTokenTypes.opGREATER_OR_EQUAL);
+        reverseTypes.put(PhpTokenTypes.opLESS_OR_EQUAL, PhpTokenTypes.opGREATER);
+    }
+
+    public static IElementType rotateOperation(final IElementType operation) {
+        if (reverseTypes.containsKey(operation)) {
+            return reverseTypes.get(operation);
+        }
+
+        return operation;
+    }
+}

--- a/src/main/resources/inspectionDescriptions/MagicNumberInspection.html
+++ b/src/main/resources/inspectionDescriptions/MagicNumberInspection.html
@@ -3,6 +3,17 @@
         Suggests to avoid magic numbers on code.
 
         <p><strong>Magic numbers</strong> are numeric literals used on code that could be referenced in
-            a lot of places but are not constants, then are hard to maintain.</p>
+            a lot of places but are not constants, then are hard to understand and maintain.</p>
+
+        <p>It will always report for number literals in <code>return</code> statements,
+            <code>switch</code> cases and too conditionals (except on testing counting by zero).</p>
+
+        <p><strong>Additional reporting options:</strong></p>
+        <ul>
+            <li><strong>Report for multiplier:</strong> check if a magic number is used as multiplier (excluding <code>-1</code>).</li>
+            <li><strong>Report for properties:</strong> check if a magic number is used as default value on properties (excluding <code>0</code>).</li>
+            <li><strong>Report for parameters:</strong> check if a magic number is used as default value on parameters (excluding <code>0</code>).</li>
+            <li><strong>Report for arguments:</strong> check if a magic number is used as argument (excluding <code>0</code> and the default parameter value).</li>
+        </ul>
     </body>
 </html>

--- a/src/main/resources/inspectionDescriptions/MagicNumberInspection.html
+++ b/src/main/resources/inspectionDescriptions/MagicNumberInspection.html
@@ -1,0 +1,8 @@
+<html>
+    <body>
+        Suggests to avoid magic numbers on code.
+
+        <p><strong>Magic numbers</strong> are numeric literals used on code that could be referenced in
+            a lot of places but are not constants, then are hard to maintain.</p>
+    </body>
+</html>

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspectorTest.java
@@ -1,0 +1,12 @@
+package com.kalessil.phpStorm.phpInspectionsEA.inspectors.codeSmell;
+
+import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase;
+
+public class MagicNumberInspectorTest extends CodeInsightFixtureTestCase {
+    public void testIfFindsAllPatterns() {
+        myFixture.enableInspections(new MagicNumberInspector());
+
+        myFixture.configureByFile("fixtures/codeSmell/MagicNumber.php");
+        myFixture.testHighlighting(true, false, true);
+    }
+}

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeSmell/MagicNumberInspectorTest.java
@@ -9,4 +9,44 @@ public class MagicNumberInspectorTest extends CodeInsightFixtureTestCase {
         myFixture.configureByFile("fixtures/codeSmell/MagicNumber.php");
         myFixture.testHighlighting(true, false, true);
     }
+
+    public void testOptionCheckOnMultiply() {
+        final MagicNumberInspector magicNumberInspector = new MagicNumberInspector();
+        magicNumberInspector.optionCheckOnMultiplier = false;
+
+        myFixture.enableInspections(magicNumberInspector);
+
+        myFixture.configureByFile("fixtures/codeSmell/MagicNumber.optionCheckOnMultiply-false.php");
+        myFixture.testHighlighting(true, false, true);
+    }
+
+    public void testOptionCheckOnProperties() {
+        final MagicNumberInspector magicNumberInspector = new MagicNumberInspector();
+        magicNumberInspector.optionCheckOnProperties = false;
+
+        myFixture.enableInspections(magicNumberInspector);
+
+        myFixture.configureByFile("fixtures/codeSmell/MagicNumber.optionCheckOnProperties-false.php");
+        myFixture.testHighlighting(true, false, true);
+    }
+
+    public void testOptionCheckOnParameters() {
+        final MagicNumberInspector magicNumberInspector = new MagicNumberInspector();
+        magicNumberInspector.optionCheckOnParameters = false;
+
+        myFixture.enableInspections(magicNumberInspector);
+
+        myFixture.configureByFile("fixtures/codeSmell/MagicNumber.optionCheckOnParameters-false.php");
+        myFixture.testHighlighting(true, false, true);
+    }
+
+    public void testOptionCheckOnArguments() {
+        final MagicNumberInspector magicNumberInspector = new MagicNumberInspector();
+        magicNumberInspector.optionCheckOnArguments = false;
+
+        myFixture.enableInspections(magicNumberInspector);
+
+        myFixture.configureByFile("fixtures/codeSmell/MagicNumber.optionCheckOnArguments-false.php");
+        myFixture.testHighlighting(true, false, true);
+    }
 }

--- a/src/test/resources/fixtures/codeSmell/MagicNumber.optionCheckOnArguments-false.php
+++ b/src/test/resources/fixtures/codeSmell/MagicNumber.optionCheckOnArguments-false.php
@@ -1,0 +1,4 @@
+<?php
+
+writeNumber(10);
+$this->writeNumber(10);

--- a/src/test/resources/fixtures/codeSmell/MagicNumber.optionCheckOnMultiply-false.php
+++ b/src/test/resources/fixtures/codeSmell/MagicNumber.optionCheckOnMultiply-false.php
@@ -1,0 +1,6 @@
+<?php
+
+$expressionWithMultiply * 10;
+$expressionWithMultiply * -10;
+$expressionWithMultiply *= 10;
+$expressionWithMultiply *= -10;

--- a/src/test/resources/fixtures/codeSmell/MagicNumber.optionCheckOnParameters-false.php
+++ b/src/test/resources/fixtures/codeSmell/MagicNumber.optionCheckOnParameters-false.php
@@ -1,0 +1,3 @@
+<?php
+
+function nowAllowedOnParameters($nowAllowedOnParameters = 10) { }

--- a/src/test/resources/fixtures/codeSmell/MagicNumber.optionCheckOnProperties-false.php
+++ b/src/test/resources/fixtures/codeSmell/MagicNumber.optionCheckOnProperties-false.php
@@ -1,0 +1,5 @@
+<?php
+
+class PropertyNumericClass {
+    public $someNumbericValue = 10;
+}

--- a/src/test/resources/fixtures/codeSmell/MagicNumber.php
+++ b/src/test/resources/fixtures/codeSmell/MagicNumber.php
@@ -1,5 +1,8 @@
 <?php
 
+// False-positive: generalized way to test expression type.
+$shouldNotBeTested = [ 'array' => 'value' ];
+
 // Allowed: integer zero or one are ignored by default.
 $shouldNotBeConstantByDefault_NumberZero = 0;
 $shouldNotBeConstantByDefault_NumberOne = 1;

--- a/src/test/resources/fixtures/codeSmell/MagicNumber.php
+++ b/src/test/resources/fixtures/codeSmell/MagicNumber.php
@@ -3,15 +3,11 @@
 // Allowed: should not affects pure assignments.
 $shouldNotBeConstant_ItsJustAnAssignment = 10;
 
-// Allowed: integer zero or one are ignored by default.
-return 0;
-return 1;
-
-// Warn: float zero or one are not ignored.
+// Warn: any returned integer or float.
+return <weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning>;
+return <weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning>;
 return <weak_warning descr="Magic number should be replaced by a constant.">0.0</weak_warning>;
 return <weak_warning descr="Magic number should be replaced by a constant.">1.0</weak_warning>;
-
-// Warn: any number, except zero or one, by default.
 return <weak_warning descr="Magic number should be replaced by a constant.">10</weak_warning>;
 return <weak_warning descr="Magic number should be replaced by a constant.">10.0</weak_warning>;
 

--- a/src/test/resources/fixtures/codeSmell/MagicNumber.php
+++ b/src/test/resources/fixtures/codeSmell/MagicNumber.php
@@ -1,16 +1,23 @@
 <?php
 
-// False-positive: generalized way to test expression type.
-$shouldNotBeTested = [ 'array' => 'value' ];
+// Allowed: should not affects pure assignments.
+$shouldNotBeConstant_ItsJustAnAssignment = 10;
 
 // Allowed: integer zero or one are ignored by default.
-$shouldNotBeConstantByDefault_NumberZero = 0;
-$shouldNotBeConstantByDefault_NumberOne = 1;
+return 0;
+return 1;
 
 // Warn: float zero or one are not ignored.
-$shouldBeConstant_FloatZero = <weak_warning descr="Magic number should be replaced by a constant.">0.0</weak_warning>;
-$shouldBeConstnat_FloatOne = <weak_warning descr="Magic number should be replaced by a constant.">1.0</weak_warning>;
+return <weak_warning descr="Magic number should be replaced by a constant.">0.0</weak_warning>;
+return <weak_warning descr="Magic number should be replaced by a constant.">1.0</weak_warning>;
 
 // Warn: any number, except zero or one, by default.
-$shouldBeConstant_AnyNumber = <weak_warning descr="Magic number should be replaced by a constant.">10</weak_warning>;
-$shouldBeConstant_AnyFloat = <weak_warning descr="Magic number should be replaced by a constant.">10.0</weak_warning>;
+return <weak_warning descr="Magic number should be replaced by a constant.">10</weak_warning>;
+return <weak_warning descr="Magic number should be replaced by a constant.">10.0</weak_warning>;
+
+// Allowed: ignore indirect returns.
+return $pregMatch[2];
+return sum(1, 2);
+
+// False-positive: generalized way to test expression type.
+$shouldNotBeTested = [ 'array' => 'value' ];

--- a/src/test/resources/fixtures/codeSmell/MagicNumber.php
+++ b/src/test/resources/fixtures/codeSmell/MagicNumber.php
@@ -102,6 +102,12 @@ $count >= <weak_warning descr="Magic number should be replaced by a constant.">2
 <weak_warning descr="Magic number should be replaced by a constant.">2</weak_warning> <= count($values);
 <weak_warning descr="Magic number should be replaced by a constant.">2</weak_warning> <= $this->size();
 <weak_warning descr="Magic number should be replaced by a constant.">2</weak_warning> <= $count;
+<weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning> === count($values);
+<weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning> !== count($values);
+<weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning> === $this->size();
+<weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning> !== $this->size();
+<weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning> === $count;
+<weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning> !== $count;
 
 // Warn: if used on switch.
 switch (getSomeNumber()) {

--- a/src/test/resources/fixtures/codeSmell/MagicNumber.php
+++ b/src/test/resources/fixtures/codeSmell/MagicNumber.php
@@ -19,5 +19,12 @@ return sum(1, 2);
 $binaryExpressionOnLeft  = <weak_warning descr="Magic number should be replaced by a constant.">5</weak_warning> < $number;
 $binaryExpressionOnRight = $number > <weak_warning descr="Magic number should be replaced by a constant.">5</weak_warning>;
 
-// False-positive: generalized way to test expression type.
-$shouldNotBeTested = [ 'array' => 'value' ];
+// False-positive: is not a number.
+$shouldNotBeTested    = [ 'array' => 'value' ];
+
+// False-positive: typehinted is not a numeric literal.
+class TypehintCheck {
+    private $isNotANumericLiteral = 0;
+    public function propertyIsNotANumericLiteral() { $this->isNotANumericLiteral !== null; }
+    public function parameterIsNotANumericLiteral(int $number) { $number !== null; }
+}

--- a/src/test/resources/fixtures/codeSmell/MagicNumber.php
+++ b/src/test/resources/fixtures/codeSmell/MagicNumber.php
@@ -29,17 +29,79 @@ class TypehintCheck {
     public function parameterIsNotANumericLiteral(int $number) { $number !== null; }
 }
 
-// Allowed: zero is allowed in binary expression if one of operands is a function reference.
-return count($values) > 0;
-return $this->size() > 0;
-return 0 > count($values);
-return 0 > $this->size();
+// Allowed: zero or one is allowed in binary expression if is used for counting.
+count($values) >  0;
+count($values) >  1;
+count($values) >= 0;
+count($values) >= 1;
+$this->size() >  0;
+$this->size() >  1;
+$this->size() >= 0;
+$this->size() >= 1;
+$count >  0;
+$count >  1;
+$count >= 0;
+$count >= 1;
+0 <  count($values);
+1 <  count($values);
+0 <= count($values);
+1 <= count($values);
+0 <  $this->size();
+1 <  $this->size();
+0 <= $this->size();
+1 <= $this->size();
+0 <  $count;
+1 <  $count;
+0 <= $count;
+1 <= $count;
+
+// Warn: if zero or one is not used for counting.
+count($values) <  <weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning>;
+count($values) <  <weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning>;
+count($values) <= <weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning>;
+count($values) <= <weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning>;
+$this->size() <  <weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning>;
+$this->size() <  <weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning>;
+$this->size() <= <weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning>;
+$this->size() <= <weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning>;
+$count <  <weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning>;
+$count <  <weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning>;
+$count <= <weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning>;
+$count <= <weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning>;
+<weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning> >  count($values);
+<weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning> >  count($values);
+<weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning> >= count($values);
+<weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning> >= count($values);
+<weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning> >  $this->size();
+<weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning> >  $this->size();
+<weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning> >= $this->size();
+<weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning> >= $this->size();
+<weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning> >  $count;
+<weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning> >  $count;
+<weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning> >= $count;
+<weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning> >= $count;
+
+// Allowed: zero is allowed in binary expression if used for counting zero elements.
+count($values) === 0;
+count($values) !== 0;
+$this->size() === 0;
+$this->size() !== 0;
+$count === 0;
+$count !== 0;
+0 === count($values);
+0 !== count($values);
+0 === $this->size();
+0 !== $this->size();
+0 === $count;
+0 !== $count;
 
 // Warn: it is not applicable to other values.
-return count($values) >= <weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning>;
-return $this->size() >= <weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning>;
-return <weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning> >= count($values);
-return <weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning> >= $this->size();
+count($values) >= <weak_warning descr="Magic number should be replaced by a constant.">2</weak_warning>;
+$this->size() >= <weak_warning descr="Magic number should be replaced by a constant.">2</weak_warning>;
+$count >= <weak_warning descr="Magic number should be replaced by a constant.">2</weak_warning>;
+<weak_warning descr="Magic number should be replaced by a constant.">2</weak_warning> <= count($values);
+<weak_warning descr="Magic number should be replaced by a constant.">2</weak_warning> <= $this->size();
+<weak_warning descr="Magic number should be replaced by a constant.">2</weak_warning> <= $count;
 
 // Warn: if used on switch.
 switch (getSomeNumber()) {

--- a/src/test/resources/fixtures/codeSmell/MagicNumber.php
+++ b/src/test/resources/fixtures/codeSmell/MagicNumber.php
@@ -126,3 +126,13 @@ class PropertyNumericClass {
     public $zeroValue  = 0;
     public $ignoreThat = self::IGNORE_THAT;
 }
+
+// Warn: number used in multiply expression.
+$expressionWithMultiply * <weak_warning descr="Magic number should be replaced by a constant.">10</weak_warning>;
+$expressionWithMultiply * <weak_warning descr="Magic number should be replaced by a constant.">-10</weak_warning>;
+$expressionWithMultiply *= <weak_warning descr="Magic number should be replaced by a constant.">10</weak_warning>;
+$expressionWithMultiply *= <weak_warning descr="Magic number should be replaced by a constant.">-10</weak_warning>;
+
+// Allowed: number -1 used in multiply.
+$expressionWithMultiply * -1;
+$expressionWithMultiply *= -1;

--- a/src/test/resources/fixtures/codeSmell/MagicNumber.php
+++ b/src/test/resources/fixtures/codeSmell/MagicNumber.php
@@ -142,3 +142,9 @@ $expressionWithMultiply *= <weak_warning descr="Magic number should be replaced 
 // Allowed: number -1 used in multiply.
 $expressionWithMultiply * -1;
 $expressionWithMultiply *= -1;
+
+// Warn: used as default value for parameters.
+function shouldNotBeAllowedOnParameter($shouldNotBeAllowedOnParameter = <weak_warning descr="Magic number should be replaced by a constant.">10</weak_warning>) { }
+
+// Allowed: except by zero.
+function shouldAcceptOnlyZeroOnParameter($shouldAcceptOnlyZeroOnParameter = 0) { }

--- a/src/test/resources/fixtures/codeSmell/MagicNumber.php
+++ b/src/test/resources/fixtures/codeSmell/MagicNumber.php
@@ -40,3 +40,10 @@ return count($values) >= <weak_warning descr="Magic number should be replaced by
 return $this->size() >= <weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning>;
 return <weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning> >= count($values);
 return <weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning> >= $this->size();
+
+// Warn: if used on switch.
+switch (getSomeNumber()) {
+    case <weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning>: $anyNumberEvenZero = true; break;
+    case <weak_warning descr="Magic number should be replaced by a constant.">5</weak_warning>: $anyOtherNumber    = true; break;
+    default: $shouldBeJustIgnored = true; break;
+}

--- a/src/test/resources/fixtures/codeSmell/MagicNumber.php
+++ b/src/test/resources/fixtures/codeSmell/MagicNumber.php
@@ -13,7 +13,6 @@ return <weak_warning descr="Magic number should be replaced by a constant.">10.0
 
 // Allowed: ignore indirect returns.
 return $pregMatch[2];
-return sum(1, 2);
 
 // Warn: using in binary expression.
 $binaryExpressionOnLeft  = <weak_warning descr="Magic number should be replaced by a constant.">5</weak_warning> < $number;
@@ -148,3 +147,14 @@ function shouldNotBeAllowedOnParameter($shouldNotBeAllowedOnParameter = <weak_wa
 
 // Allowed: except by zero.
 function shouldAcceptOnlyZeroOnParameter($shouldAcceptOnlyZeroOnParameter = 0) { }
+
+// Warn: used as argument.
+writeNumber(<weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning>);
+writeNumber(<weak_warning descr="Magic number should be replaced by a constant.">10</weak_warning>);
+$this->writeNumber(<weak_warning descr="Magic number should be replaced by a constant.">10</weak_warning>);
+
+// Allowed: except if it matches with the default value (even for long constant references).
+const NUMBER_TEN = 10;
+const NUMBER_TEN_REFERENCE = NUMBER_TEN;
+function sameAsDefaultValue($defaultValue = NUMBER_TEN_REFERENCE) { }
+sameAsDefaultValue(10);

--- a/src/test/resources/fixtures/codeSmell/MagicNumber.php
+++ b/src/test/resources/fixtures/codeSmell/MagicNumber.php
@@ -109,3 +109,8 @@ switch (getSomeNumber()) {
     case <weak_warning descr="Magic number should be replaced by a constant.">5</weak_warning>: $anyOtherNumber    = true; break;
     default: $shouldBeJustIgnored = true; break;
 }
+
+// Warn: negative values should be affected too.
+$negativeValue >= <weak_warning descr="Magic number should be replaced by a constant.">-10</weak_warning>;
+$negativeValue >= <weak_warning descr="Magic number should be replaced by a constant.">-1</weak_warning>;
+$negativeValue >= <weak_warning descr="Magic number should be replaced by a constant.">-0</weak_warning>;

--- a/src/test/resources/fixtures/codeSmell/MagicNumber.php
+++ b/src/test/resources/fixtures/codeSmell/MagicNumber.php
@@ -15,5 +15,9 @@ return <weak_warning descr="Magic number should be replaced by a constant.">10.0
 return $pregMatch[2];
 return sum(1, 2);
 
+// Warn: using in binary expression.
+$binaryExpressionOnLeft  = <weak_warning descr="Magic number should be replaced by a constant.">5</weak_warning> < $number;
+$binaryExpressionOnRight = $number > <weak_warning descr="Magic number should be replaced by a constant.">5</weak_warning>;
+
 // False-positive: generalized way to test expression type.
 $shouldNotBeTested = [ 'array' => 'value' ];

--- a/src/test/resources/fixtures/codeSmell/MagicNumber.php
+++ b/src/test/resources/fixtures/codeSmell/MagicNumber.php
@@ -114,3 +114,15 @@ switch (getSomeNumber()) {
 $negativeValue >= <weak_warning descr="Magic number should be replaced by a constant.">-10</weak_warning>;
 $negativeValue >= <weak_warning descr="Magic number should be replaced by a constant.">-1</weak_warning>;
 $negativeValue >= <weak_warning descr="Magic number should be replaced by a constant.">-0</weak_warning>;
+
+class PropertyNumericClass {
+    // Allowed: const should not be checked.
+    const IGNORE_THAT = 10;
+
+    // Warn: properties should not be numberic too.
+    public $someNumbericValue = <weak_warning descr="Magic number should be replaced by a constant.">10</weak_warning>;
+
+    // Allowed: except for zero.
+    public $zeroValue  = 0;
+    public $ignoreThat = self::IGNORE_THAT;
+}

--- a/src/test/resources/fixtures/codeSmell/MagicNumber.php
+++ b/src/test/resources/fixtures/codeSmell/MagicNumber.php
@@ -28,3 +28,15 @@ class TypehintCheck {
     public function propertyIsNotANumericLiteral() { $this->isNotANumericLiteral !== null; }
     public function parameterIsNotANumericLiteral(int $number) { $number !== null; }
 }
+
+// Allowed: zero is allowed in binary expression if one of operands is a function reference.
+return count($values) > 0;
+return $this->size() > 0;
+return 0 > count($values);
+return 0 > $this->size();
+
+// Warn: it is not applicable to other values.
+return count($values) >= <weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning>;
+return $this->size() >= <weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning>;
+return <weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning> >= count($values);
+return <weak_warning descr="Magic number should be replaced by a constant.">1</weak_warning> >= $this->size();

--- a/src/test/resources/fixtures/codeSmell/MagicNumber.php
+++ b/src/test/resources/fixtures/codeSmell/MagicNumber.php
@@ -158,3 +158,15 @@ const NUMBER_TEN = 10;
 const NUMBER_TEN_REFERENCE = NUMBER_TEN;
 function sameAsDefaultValue($defaultValue = NUMBER_TEN_REFERENCE) { }
 sameAsDefaultValue(10);
+
+// Warn: using zero as argument to a not int parameter.
+function mixedParameterFunction($mixed) {}
+
+mixedParameterFunction(<weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning>);
+
+// Allowed: using zero as argument to int parameter.
+function intParameterFunction(int $int) {}
+function nullableIntParameterFunction(?int $int) {}
+
+intParameterFunction(0);
+nullableIntParameterFunction(0);

--- a/src/test/resources/fixtures/codeSmell/MagicNumber.php
+++ b/src/test/resources/fixtures/codeSmell/MagicNumber.php
@@ -1,0 +1,13 @@
+<?php
+
+// Allowed: integer zero or one are ignored by default.
+$shouldNotBeConstantByDefault_NumberZero = 0;
+$shouldNotBeConstantByDefault_NumberOne = 1;
+
+// Warn: float zero or one are not ignored.
+$shouldBeConstant_FloatZero = <weak_warning descr="Magic number should be replaced by a constant.">0.0</weak_warning>;
+$shouldBeConstnat_FloatOne = <weak_warning descr="Magic number should be replaced by a constant.">1.0</weak_warning>;
+
+// Warn: any number, except zero or one, by default.
+$shouldBeConstant_AnyNumber = <weak_warning descr="Magic number should be replaced by a constant.">10</weak_warning>;
+$shouldBeConstant_AnyFloat = <weak_warning descr="Magic number should be replaced by a constant.">10.0</weak_warning>;

--- a/src/test/resources/fixtures/codeSmell/MagicNumber.php
+++ b/src/test/resources/fixtures/codeSmell/MagicNumber.php
@@ -174,4 +174,14 @@ nullableIntParameterFunction(0);
 // Internal: avoiding loopings.
 define("null", null);
 function avoidLoopings($defaultValue = null) { }
-avoidLoopings(10);
+avoidLoopings(<weak_warning descr="Magic number should be replaced by a constant.">10</weak_warning>);
+
+// Internal (NPE): check parameter size before get it.
+function fewParameters($parameter) { }
+fewParameters(<weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning>,
+              <weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning>,
+              <weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning>);
+function fewParametersList(...$parameters) { }
+fewParameters(<weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning>,
+              <weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning>,
+              <weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning>);

--- a/src/test/resources/fixtures/codeSmell/MagicNumber.php
+++ b/src/test/resources/fixtures/codeSmell/MagicNumber.php
@@ -170,3 +170,8 @@ function nullableIntParameterFunction(?int $int) {}
 
 intParameterFunction(0);
 nullableIntParameterFunction(0);
+
+// Internal: avoiding loopings.
+define("null", null);
+function avoidLoopings($defaultValue = null) { }
+avoidLoopings(10);

--- a/src/test/resources/fixtures/codeSmell/MagicNumber.php
+++ b/src/test/resources/fixtures/codeSmell/MagicNumber.php
@@ -149,8 +149,9 @@ function shouldNotBeAllowedOnParameter($shouldNotBeAllowedOnParameter = <weak_wa
 function shouldAcceptOnlyZeroOnParameter($shouldAcceptOnlyZeroOnParameter = 0) { }
 
 // Warn: used as argument.
-writeNumber(<weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning>);
+writeNumber(0);
 writeNumber(<weak_warning descr="Magic number should be replaced by a constant.">10</weak_warning>);
+$this->writeNumber(0);
 $this->writeNumber(<weak_warning descr="Magic number should be replaced by a constant.">10</weak_warning>);
 
 // Allowed: except if it matches with the default value (even for long constant references).
@@ -159,17 +160,17 @@ const NUMBER_TEN_REFERENCE = NUMBER_TEN;
 function sameAsDefaultValue($defaultValue = NUMBER_TEN_REFERENCE) { }
 sameAsDefaultValue(10);
 
-// Warn: using zero as argument to a not int parameter.
+// Allowed: using zero as argument to a not int parameter.
 function mixedParameterFunction($mixed) {}
-
-mixedParameterFunction(<weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning>);
-
-// Allowed: using zero as argument to int parameter.
 function intParameterFunction(int $int) {}
 function nullableIntParameterFunction(?int $int) {}
 
+mixedParameterFunction(0);
+mixedParameterFunction(<weak_warning descr="Magic number should be replaced by a constant.">10</weak_warning>);
 intParameterFunction(0);
+intParameterFunction(<weak_warning descr="Magic number should be replaced by a constant.">10</weak_warning>);
 nullableIntParameterFunction(0);
+nullableIntParameterFunction(<weak_warning descr="Magic number should be replaced by a constant.">10</weak_warning>);
 
 // Internal: avoiding loopings.
 define("null", null);
@@ -178,10 +179,6 @@ avoidLoopings(<weak_warning descr="Magic number should be replaced by a constant
 
 // Internal (NPE): check parameter size before get it.
 function fewParameters($parameter) { }
-fewParameters(<weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning>,
-              <weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning>,
-              <weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning>);
+fewParameters(0, 0, <weak_warning descr="Magic number should be replaced by a constant.">10</weak_warning>);
 function fewParametersList(...$parameters) { }
-fewParameters(<weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning>,
-              <weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning>,
-              <weak_warning descr="Magic number should be replaced by a constant.">0</weak_warning>);
+fewParametersList(0, 0, <weak_warning descr="Magic number should be replaced by a constant.">10</weak_warning>);


### PR DESCRIPTION
Fixes #293 

It add a lot of analyses to magic numbers, based on [povils/phpmnd](https://github.com/povils/phpmnd) possibilities (except for _arrays_ and _assign_).

**It could** (always enabled):

* **Report for return:** will check for _magic number_ used with the `return` statement in a simple way (eg. `return 0`). Not will check in cases like `return $a = 5`, but we can change that;
* **Report for switch cases:** will check for magic number used as argument for `case` from a `switch` statement (eg. `case 0`);
* **Report for conditionals:** will check for magic number used as operand on a conditional (eg. `$value > 5` or reverse). It will ignore if detects that we are just counting (eg. `count($values) > 0`), but is not too much flexible, then if I do `count($values) > 5`, then `5` is a magic number (_after all, why 5?_).

**Additionally, it could** (_configured by option, but currently enabled by default_):

* **Report on multipler:** will check for magic number as multipler (eg. `$seconds * 60`), except for `-1` because it could be used to change number signal (from positive-to-negative, and reverse);
* **Report on properties:** will check for magic number as default value of properties (eg `public $number = 5`), except if value is `0` (_although I prefer null, in these cases_).
* **Report on parameters:** will check for magic number as default value of parameters (eg. `function ($precision = 8)`), except if value is `0`.
* **Report on arguments:** will check for magic number as argument (eg. `sum($a, 50)`), except if argument is `0` or is the same as the default parameter value (it will follow constant value to identify the resolved number, then it could work together with the previous option without problems).

---

* [x] Implemented with UTs for all cases and options;
* [x] For some reason, options are not been saved. _Some clue?_

Currently without QFs, because it need a more complex process (maybe on future).