### PR TITLE
Add some additional dev packages to the securityAdvisories check

### DIFF
--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/security/SecurityAdvisoriesInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/security/SecurityAdvisoriesInspector.java
@@ -38,9 +38,11 @@ public class SecurityAdvisoriesInspector extends LocalInspectionTool {
         /* more dev-packages  */
         developmentPackages.add("mockery/mockery");
         developmentPackages.add("behat/behat");
+        developmentPackages.add("phpspec/prophecy");
         developmentPackages.add("phpspec/phpspec");
         developmentPackages.add("composer/composer");
         developmentPackages.add("satooshi/php-coveralls");
+        developmentPackages.add("phpro/grumphp");
         /* SCA tools */
         developmentPackages.add("friendsofphp/php-cs-fixer");
         developmentPackages.add("squizlabs/php_codesniffer");
@@ -51,6 +53,7 @@ public class SecurityAdvisoriesInspector extends LocalInspectionTool {
         developmentPackages.add("phpmd/phpmd");
         developmentPackages.add("pdepend/pdepend");
         developmentPackages.add("sebastian/phpcpd");
+        developmentPackages.add("povils/phpmnd");
     }
 
     @NotNull


### PR DESCRIPTION
I've added 2 more packages which should be required as dev dependency. Couldn't think of more commonly used packages at the moment. 
I've did a quick scroll through https://github.com/exakat/php-static-analysis-tools, you might find one or two more.