### PR TITLE
[#146] References by "new self" instead of "new MyClass"

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -646,6 +646,10 @@ Like the plugin? Become <a href="https://www.patreon.com/kalessil">a patron</a>!
         shortName="UnnecessaryCastingInspection"                  displayName="Unnecessary type casting"
         groupName="Code Style"                                    enabledByDefault="true" level="WEAK WARNING"
         implementationClass="com.kalessil.phpStorm.phpInspectionsEA.inspectors.codeSmell.UnnecessaryCastingInspector"/>
+    <localInspection language="PHP" groupPath="PHP,Php Inspections (EA Extended)"
+        shortName="SelfClassReferencingInspection"                displayName="Self class referencing"
+        groupName="Code Style"                                    enabledByDefault="true" level="WEAK WARNING"
+        implementationClass="com.kalessil.phpStorm.phpInspectionsEA.inspectors.codeStyle.SelfClassReferencingInspector"/>
 
 
     <localInspection language="PHP" groupPath="PHP,Php Inspections (EA Extended)"

--- a/RULES.md
+++ b/RULES.md
@@ -112,6 +112,7 @@ Inspections Lists (Code style)
 | Code Style           | DisallowWritingIntoStaticPropertiesInspection   | Disallow writing into static properties             | n/a | yes | n/a  | no  |
 | Code Style           | UsageOfSilenceOperatorInspection                | Usage of the silence operator                       | yes | yes | no   | yes |
 | Code Style           | UnnecessaryCastingInspection                    | Unnecessary type casting                            | yes | yes | yes  | no  |
+| Code Style           | SelfClassReferencingInspection                  | Self class referencing                              | no  | yes | no   | no  |
 
 Inspections Lists (Language level migration)
 ---

--- a/RULES.md
+++ b/RULES.md
@@ -112,7 +112,7 @@ Inspections Lists (Code style)
 | Code Style           | DisallowWritingIntoStaticPropertiesInspection   | Disallow writing into static properties             | n/a | yes | n/a  | no  |
 | Code Style           | UsageOfSilenceOperatorInspection                | Usage of the silence operator                       | yes | yes | no   | yes |
 | Code Style           | UnnecessaryCastingInspection                    | Unnecessary type casting                            | yes | yes | yes  | no  |
-| Code Style           | SelfClassReferencingInspection                  | Self class referencing                              | no  | yes | no   | no  |
+| Code Style           | SelfClassReferencingInspection                  | Self class referencing                              | yes | yes | yes  | no  |
 
 Inspections Lists (Language level migration)
 ---

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeStyle/SelfClassReferencingInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeStyle/SelfClassReferencingInspector.java
@@ -86,9 +86,8 @@ public class SelfClassReferencingInspector extends BasePhpInspection {
                     return false;
                 }
 
-                if (optionPreferClass &&
-                    "self".equals(classReference.getName())) {
-                    return true;
+                if (optionPreferClass) {
+                    return "self".equals(classReference.getName());
                 }
 
                 final String classReferenceName = classReference.getName();

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeStyle/SelfClassReferencingInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeStyle/SelfClassReferencingInspector.java
@@ -91,6 +91,13 @@ public class SelfClassReferencingInspector extends BasePhpInspection {
                     return true;
                 }
 
+                final String classReferenceName = classReference.getName();
+
+                if ("self".equals(classReferenceName) ||
+                    "static".equals(classReferenceName)) {
+                    return false;
+                }
+
                 final PhpClass expressionParentClass = PsiTreeUtil.getParentOfType(psiElement, PhpClass.class);
 
                 return (expressionParentClass != null) &&
@@ -115,16 +122,18 @@ public class SelfClassReferencingInspector extends BasePhpInspection {
             private void validateClassConstantComponent(@NotNull final PsiElement constantReference, @Nullable final PhpReference classReference) {
                 if (isSameFQN(constantReference, classReference)) {
                     registerProblem(classReference.getParent(), getClassName(classReference) + "::class", "__CLASS__");
-                }
+                    }
             }
 
             private void validateCommonComponent(final PsiElement expression, @Nullable final PhpReference classReference) {
                 if (isSameFQN(expression, classReference)) {
                     final String className = getClassName(classReference);
 
-                    if ((className != null) && (!className.isEmpty())) {
-                        registerProblem(classReference, className, "self");
+                    if ((className == null) || (className.isEmpty())) {
+                        return;
                     }
+
+                    registerProblem(classReference, className, "self");
                 }
             }
 

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeStyle/SelfClassReferencingInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeStyle/SelfClassReferencingInspector.java
@@ -1,0 +1,73 @@
+package com.kalessil.phpStorm.phpInspectionsEA.inspectors.codeStyle;
+
+import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.jetbrains.php.lang.psi.elements.ClassConstantReference;
+import com.jetbrains.php.lang.psi.elements.FieldReference;
+import com.jetbrains.php.lang.psi.elements.MethodReference;
+import com.jetbrains.php.lang.psi.elements.NewExpression;
+import com.jetbrains.php.lang.psi.elements.PhpClass;
+import com.jetbrains.php.lang.psi.elements.PhpReference;
+import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
+import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class SelfClassReferencingInspector extends BasePhpInspection {
+    private static final String messageSelfReplacement  = "Class reference \"%s\" could be replaced by \"self\"";
+
+    @NotNull
+    public String getShortName() {
+        return "SelfClassReferencingInspection";
+    }
+
+    @NotNull
+    @Override
+    public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder problemsHolder, final boolean b) {
+        return new BasePhpElementVisitor() {
+            @Override
+            public void visitPhpNewExpression(final NewExpression expression) {
+                validateCommonComponent(expression, expression.getClassReference());
+            }
+
+            @Override
+            public void visitPhpMethodReference(final MethodReference reference) {
+                if (reference.isStatic()) {
+                    validateCommonComponent(reference, (PhpReference) reference.getClassReference());
+                }
+            }
+
+            @Override
+            public void visitPhpClassConstantReference(final ClassConstantReference constantReference) {
+                validateCommonComponent(constantReference, (PhpReference) constantReference.getClassReference());
+            }
+
+            @Override
+            public void visitPhpFieldReference(final FieldReference fieldReference) {
+                if (fieldReference.isStatic()) {
+                    validateCommonComponent(fieldReference, (PhpReference) fieldReference.getClassReference());
+                }
+            }
+
+            private boolean isSameFQN(@NotNull final PsiElement constantReference, @Nullable final PhpReference classReference) {
+                if (classReference == null) {
+                    return false;
+                }
+
+                final PhpClass expressionParentClass = PsiTreeUtil.getParentOfType(constantReference, PhpClass.class);
+
+                return (expressionParentClass != null) &&
+                       (expressionParentClass.getFQN().equals(classReference.getFQN()));
+            }
+
+            private void validateCommonComponent(final PsiElement expression, @Nullable final PhpReference classReference) {
+                if (isSameFQN(expression, classReference)) {
+                    problemsHolder.registerProblem(classReference, String.format(messageSelfReplacement, classReference.getName()));
+                }
+            }
+        };
+    }
+}

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeStyle/SelfClassReferencingInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeStyle/SelfClassReferencingInspector.java
@@ -131,12 +131,6 @@ public class SelfClassReferencingInspector extends BasePhpInspection {
                         return;
                     }
 
-                    final String classReferenceText = classReference.getText();
-
-                    if ("__CLASS__".equals(classReferenceText)) {
-                        registerProblem(classReference.getParent(), className + "::class", classReferenceText);
-                    }
-
                     final String classReferenceName = classReference.getName();
 
                     if (classReferenceName == null) {

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeStyle/SelfClassReferencingInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeStyle/SelfClassReferencingInspector.java
@@ -24,6 +24,17 @@ import javax.swing.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/*
+ * This file is part of the Php Inspections (EA Extended) package.
+ *
+ * (c) David Rodrigues <david.proweb@gmail.com>
+ * (c) Funivan <alotofall@gmail.com>
+ * (c) Vladimir Reznichenko <kalessil@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 public class SelfClassReferencingInspector extends BasePhpInspection {
     private static final String messageReplacement = "Class reference \"%s\" could be replaced by \"%s\"";
 

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeStyle/SelfClassReferencingInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeStyle/SelfClassReferencingInspector.java
@@ -122,7 +122,8 @@ public class SelfClassReferencingInspector extends BasePhpInspection {
 
                 final PhpClass expressionParentClass = PsiTreeUtil.getParentOfType(psiElement, PhpClass.class);
 
-                if (expressionParentClass == null) {
+                if ((expressionParentClass == null) ||
+                    (expressionParentClass.isAnonymous())) {
                     return null;
                 }
 

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeStyle/SelfClassReferencingInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeStyle/SelfClassReferencingInspector.java
@@ -121,8 +121,31 @@ public class SelfClassReferencingInspector extends BasePhpInspection {
 
             private void validateClassConstantComponent(@NotNull final PsiElement constantReference, @Nullable final PhpReference classReference) {
                 if (isSameFQN(constantReference, classReference)) {
-                    registerProblem(classReference.getParent(), getClassName(classReference) + "::class", "__CLASS__");
+                    if (!optionPreferClass) {
+                        registerProblem(classReference.getParent(), getClassName(classReference) + "::class", "__CLASS__");
+                        return;
                     }
+
+                    final String className = getClassName(classReference);
+
+                    if ((className == null) || (className.isEmpty())) {
+                        return;
+                    }
+
+                    final String classReferenceText = classReference.getText();
+
+                    if ("__CLASS__".equals(classReferenceText)) {
+                        registerProblem(classReference.getParent(), className + "::class", classReferenceText);
+                    }
+
+                    final String classReferenceName = classReference.getName();
+
+                    if (classReferenceName == null) {
+                        return;
+                    }
+
+                    registerProblem(classReference, className, classReferenceName);
+                }
             }
 
             private void validateCommonComponent(final PsiElement expression, @Nullable final PhpReference classReference) {

--- a/src/main/resources/inspectionDescriptions/SelfClassReferencingInspection.html
+++ b/src/main/resources/inspectionDescriptions/SelfClassReferencingInspection.html
@@ -1,0 +1,13 @@
+<html>
+    <body>
+        Suggests a replacement for <code>new OwnClass</code> to <code>new self</code>.
+
+        <p><strong>Supports to:</strong></p>
+        <ul>
+            <li><code>new OwnClass</code></li>
+            <li><code>OwnClass::CONSTANT</code></li>
+            <li><code>OwnClass::staticMethod()</code></li>
+            <li><code>OwnClass::$staticProperty</code></li>
+        </ul>
+    </body>
+</html>

--- a/src/main/resources/inspectionDescriptions/SelfClassReferencingInspection.html
+++ b/src/main/resources/inspectionDescriptions/SelfClassReferencingInspection.html
@@ -8,6 +8,7 @@
             <li><code>OwnClass::CONSTANT</code></li>
             <li><code>OwnClass::staticMethod()</code></li>
             <li><code>OwnClass::$staticProperty</code></li>
+            <li><code>OwnClass::class</code> to <code>__CLASS__</code></li>
         </ul>
     </body>
 </html>

--- a/src/main/resources/inspectionDescriptions/SelfClassReferencingInspection.html
+++ b/src/main/resources/inspectionDescriptions/SelfClassReferencingInspection.html
@@ -1,14 +1,16 @@
 <html>
     <body>
-        Suggests a replacement for <code>new OwnClass</code> to <code>new self</code>.
+        Suggests a replacement from <code>new MyClass</code> to <code>new self</code>.
 
         <p><strong>Supports to:</strong></p>
         <ul>
-            <li><code>new OwnClass</code></li>
-            <li><code>OwnClass::CONSTANT</code></li>
-            <li><code>OwnClass::staticMethod()</code></li>
-            <li><code>OwnClass::$staticProperty</code></li>
-            <li><code>OwnClass::class</code> to <code>__CLASS__</code></li>
+            <li><code>new MyClass</code>;</li>
+            <li><code>MyClass::CONSTANT</code>;</li>
+            <li><code>MyClass::staticMethod()</code>;</li>
+            <li><code>MyClass::$staticProperty</code>;</li>
+            <li><code>MyClass::class</code> to <code>__CLASS__</code>;</li>
         </ul>
+
+        <p>The option <strong>prefer class name referencing</strong> will do the opposite effect.</p>
     </body>
 </html>

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeStyle/SelfClassReferencingInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeStyle/SelfClassReferencingInspectorTest.java
@@ -1,13 +1,25 @@
 package com.kalessil.phpStorm.phpInspectionsEA.inspectors.codeStyle;
 
-import com.intellij.codeInsight.intention.IntentionAction;
 import com.kalessil.phpStorm.phpInspectionsEA.PhpCodeInsightFixtureTestCase;
 
 public class SelfClassReferencingInspectorTest extends PhpCodeInsightFixtureTestCase {
-    public void testIfFindsAllPatterns() {
-        myFixture.enableInspections(new SelfClassReferencingInspector());
+    public void testDefault() {
+        final SelfClassReferencingInspector selfClassReferencingInspector = new SelfClassReferencingInspector();
+        selfClassReferencingInspector.optionPreferClass = false;
+
+        myFixture.enableInspections(selfClassReferencingInspector);
 
         myFixture.configureByFile("fixtures/codeStyle/self-class-referencing.php");
+        myFixture.testHighlighting(true, false, true);
+    }
+
+    public void testReverse() {
+        final SelfClassReferencingInspector selfClassReferencingInspector = new SelfClassReferencingInspector();
+        selfClassReferencingInspector.optionPreferClass = true;
+
+        myFixture.enableInspections(selfClassReferencingInspector);
+
+        myFixture.configureByFile("fixtures/codeStyle/self-class-referencing.reverse.php");
         myFixture.testHighlighting(true, false, true);
     }
 }

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeStyle/SelfClassReferencingInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeStyle/SelfClassReferencingInspectorTest.java
@@ -1,0 +1,13 @@
+package com.kalessil.phpStorm.phpInspectionsEA.inspectors.codeStyle;
+
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.kalessil.phpStorm.phpInspectionsEA.PhpCodeInsightFixtureTestCase;
+
+public class SelfClassReferencingInspectorTest extends PhpCodeInsightFixtureTestCase {
+    public void testIfFindsAllPatterns() {
+        myFixture.enableInspections(new SelfClassReferencingInspector());
+
+        myFixture.configureByFile("fixtures/codeStyle/self-class-referencing.php");
+        myFixture.testHighlighting(true, false, true);
+    }
+}

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeStyle/SelfClassReferencingInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeStyle/SelfClassReferencingInspectorTest.java
@@ -1,5 +1,6 @@
 package com.kalessil.phpStorm.phpInspectionsEA.inspectors.codeStyle;
 
+import com.intellij.codeInsight.intention.IntentionAction;
 import com.kalessil.phpStorm.phpInspectionsEA.PhpCodeInsightFixtureTestCase;
 
 public class SelfClassReferencingInspectorTest extends PhpCodeInsightFixtureTestCase {
@@ -11,6 +12,13 @@ public class SelfClassReferencingInspectorTest extends PhpCodeInsightFixtureTest
 
         myFixture.configureByFile("fixtures/codeStyle/self-class-referencing.php");
         myFixture.testHighlighting(true, false, true);
+
+        for (final IntentionAction fix : myFixture.getAllQuickFixes()) {
+            myFixture.launchAction(fix);
+        }
+
+        myFixture.setTestDataPath(".");
+        myFixture.checkResultByFile("fixtures/codeStyle/self-class-referencing.fixed.php");
     }
 
     public void testReverse() {
@@ -21,5 +29,12 @@ public class SelfClassReferencingInspectorTest extends PhpCodeInsightFixtureTest
 
         myFixture.configureByFile("fixtures/codeStyle/self-class-referencing.reverse.php");
         myFixture.testHighlighting(true, false, true);
+
+        for (final IntentionAction fix : myFixture.getAllQuickFixes()) {
+            myFixture.launchAction(fix);
+        }
+
+        myFixture.setTestDataPath(".");
+        myFixture.checkResultByFile("fixtures/codeStyle/self-class-referencing.reverse.fixed.php");
     }
 }

--- a/src/test/resources/fixtures/codeStyle/self-class-referencing.fixed.php
+++ b/src/test/resources/fixtures/codeStyle/self-class-referencing.fixed.php
@@ -1,0 +1,26 @@
+<?php
+
+class MyClass {
+    public function method() {
+        new self;
+        self::CONSTANT;
+        self::staticMethod();
+        self::$staticProperty;
+
+        __CLASS__;
+    }
+
+    // Not applicable: anonymous class is another context.
+    public function anonymousClass() {
+        return new class {
+            public function method() {
+                new MyClass;
+                MyClass::CONSTANT;
+                MyClass::staticMethod();
+                MyClass::$staticProperty;
+
+                MyClass::class;
+            }
+        };
+    }
+}

--- a/src/test/resources/fixtures/codeStyle/self-class-referencing.fixed.php
+++ b/src/test/resources/fixtures/codeStyle/self-class-referencing.fixed.php
@@ -8,6 +8,10 @@ class MyClass {
         self::$staticProperty;
 
         __CLASS__;
+
+        // False-positives:
+        self::class;
+        static::class;
     }
 
     // Not applicable: anonymous class is another context.

--- a/src/test/resources/fixtures/codeStyle/self-class-referencing.php
+++ b/src/test/resources/fixtures/codeStyle/self-class-referencing.php
@@ -6,5 +6,7 @@ class MyClass {
         <weak_warning descr="Class reference \"MyClass\" could be replaced by \"self\"">MyClass</weak_warning>::CONSTANT;
         <weak_warning descr="Class reference \"MyClass\" could be replaced by \"self\"">MyClass</weak_warning>::staticMethod();
         <weak_warning descr="Class reference \"MyClass\" could be replaced by \"self\"">MyClass</weak_warning>::$staticProperty;
+
+        <weak_warning descr="Class reference \"MyClass::class\" could be replaced by \"__CLASS__\"">MyClass::class</weak_warning>;
     }
 }

--- a/src/test/resources/fixtures/codeStyle/self-class-referencing.php
+++ b/src/test/resources/fixtures/codeStyle/self-class-referencing.php
@@ -9,4 +9,18 @@ class MyClass {
 
         <weak_warning descr="Class reference \"MyClass::class\" could be replaced by \"__CLASS__\"">MyClass::class</weak_warning>;
     }
+
+    // Not applicable: anonymous class is another context.
+    public function anonymousClass() {
+        return new class {
+            public function method() {
+                new MyClass;
+                MyClass::CONSTANT;
+                MyClass::staticMethod();
+                MyClass::$staticProperty;
+
+                MyClass::class;
+            }
+        };
+    }
 }

--- a/src/test/resources/fixtures/codeStyle/self-class-referencing.php
+++ b/src/test/resources/fixtures/codeStyle/self-class-referencing.php
@@ -1,0 +1,10 @@
+<?php
+
+class MyClass {
+    public function method() {
+        new <weak_warning descr="Class reference \"MyClass\" could be replaced by \"self\"">MyClass</weak_warning>;
+        <weak_warning descr="Class reference \"MyClass\" could be replaced by \"self\"">MyClass</weak_warning>::CONSTANT;
+        <weak_warning descr="Class reference \"MyClass\" could be replaced by \"self\"">MyClass</weak_warning>::staticMethod();
+        <weak_warning descr="Class reference \"MyClass\" could be replaced by \"self\"">MyClass</weak_warning>::$staticProperty;
+    }
+}

--- a/src/test/resources/fixtures/codeStyle/self-class-referencing.php
+++ b/src/test/resources/fixtures/codeStyle/self-class-referencing.php
@@ -8,6 +8,10 @@ class MyClass {
         <weak_warning descr="Class reference \"MyClass\" could be replaced by \"self\"">MyClass</weak_warning>::$staticProperty;
 
         <weak_warning descr="Class reference \"MyClass::class\" could be replaced by \"__CLASS__\"">MyClass::class</weak_warning>;
+
+        // False-positives:
+        self::class;
+        static::class;
     }
 
     // Not applicable: anonymous class is another context.

--- a/src/test/resources/fixtures/codeStyle/self-class-referencing.reverse.fixed.php
+++ b/src/test/resources/fixtures/codeStyle/self-class-referencing.reverse.fixed.php
@@ -10,6 +10,7 @@ class MyClass
         MyClass::$staticProperty;
 
         MyClass::class;
+        MyClass::class;
     }
 
     // Not applicable: anonymous class is another context.

--- a/src/test/resources/fixtures/codeStyle/self-class-referencing.reverse.fixed.php
+++ b/src/test/resources/fixtures/codeStyle/self-class-referencing.reverse.fixed.php
@@ -1,0 +1,31 @@
+<?php
+
+class MyClass
+{
+    public function method()
+    {
+        new MyClass;
+        MyClass::CONSTANT;
+        MyClass::staticMethod();
+        MyClass::$staticProperty;
+
+        MyClass::class;
+    }
+
+    // Not applicable: anonymous class is another context.
+    public function anonymousClass() {
+        return new class {
+            public function method() {
+                new self;
+                self::CONSTANT;
+                self::staticMethod();
+                self::$staticProperty;
+
+                __CLASS__;
+            }
+        };
+    }
+}
+
+// Not applicable: is not inside a class.
+__CLASS__;

--- a/src/test/resources/fixtures/codeStyle/self-class-referencing.reverse.fixed.php
+++ b/src/test/resources/fixtures/codeStyle/self-class-referencing.reverse.fixed.php
@@ -11,6 +11,13 @@ class MyClass
 
         MyClass::class;
         MyClass::class;
+
+        // False-positives: already fixed.
+        new MyClass;
+        MyClass::CONSTANT;
+        MyClass::staticMethod();
+        MyClass::$staticProperty;
+        MyClass::class;
     }
 
     // Not applicable: anonymous class is another context.

--- a/src/test/resources/fixtures/codeStyle/self-class-referencing.reverse.php
+++ b/src/test/resources/fixtures/codeStyle/self-class-referencing.reverse.php
@@ -1,0 +1,31 @@
+<?php
+
+class MyClass
+{
+    public function method()
+    {
+        new <weak_warning descr="Class reference \"self\" could be replaced by \"MyClass\"">self</weak_warning>;
+        <weak_warning descr="Class reference \"self\" could be replaced by \"MyClass\"">self</weak_warning>::CONSTANT;
+        <weak_warning descr="Class reference \"self\" could be replaced by \"MyClass\"">self</weak_warning>::staticMethod();
+        <weak_warning descr="Class reference \"self\" could be replaced by \"MyClass\"">self</weak_warning>::$staticProperty;
+
+        <weak_warning descr="Class reference \"__CLASS__\" could be replaced by \"MyClass::class\"">__CLASS__</weak_warning>;
+    }
+
+    // Not applicable: anonymous class is another context.
+    public function anonymousClass() {
+        return new class {
+            public function method() {
+                new self;
+                self::CONSTANT;
+                self::staticMethod();
+                self::$staticProperty;
+
+                __CLASS__;
+            }
+        };
+    }
+}
+
+// Not applicable: is not inside a class.
+__CLASS__;

--- a/src/test/resources/fixtures/codeStyle/self-class-referencing.reverse.php
+++ b/src/test/resources/fixtures/codeStyle/self-class-referencing.reverse.php
@@ -11,6 +11,13 @@ class MyClass
 
         <weak_warning descr="Class reference \"__CLASS__\" could be replaced by \"MyClass::class\"">__CLASS__</weak_warning>;
         <weak_warning descr="Class reference \"self\" could be replaced by \"MyClass\"">self</weak_warning>::class;
+
+        // False-positives: already fixed.
+        new MyClass;
+        MyClass::CONSTANT;
+        MyClass::staticMethod();
+        MyClass::$staticProperty;
+        MyClass::class;
     }
 
     // Not applicable: anonymous class is another context.

--- a/src/test/resources/fixtures/codeStyle/self-class-referencing.reverse.php
+++ b/src/test/resources/fixtures/codeStyle/self-class-referencing.reverse.php
@@ -10,6 +10,7 @@ class MyClass
         <weak_warning descr="Class reference \"self\" could be replaced by \"MyClass\"">self</weak_warning>::$staticProperty;
 
         <weak_warning descr="Class reference \"__CLASS__\" could be replaced by \"MyClass::class\"">__CLASS__</weak_warning>;
+        <weak_warning descr="Class reference \"self\" could be replaced by \"MyClass\"">self</weak_warning>::class;
     }
 
     // Not applicable: anonymous class is another context.


### PR DESCRIPTION
It fixes #146 

* [x] Replacements (default mode):
  * [x] Replacement from `new MyClass` to `new self`;
  * [x] Replacement from `MyClass::CONSTANT` to `self::CONSTANT`;
  * [x] Replacement from `MyClass::staticMethod()` to `self::staticMethod()`;
  * [x] Replacement from `MyClass::$staticProperty` to `self::$staticProperty`;
  * [x] Replacement from `MyClass::class` to `__CLASS__`;
  * [x] Replacement from `self::class` to `__CLASS__`;
* [x] Options:
  * [x] Reserve way mode ("_prefer class name referencing_");
    * [x] Replacements (with this option enabled):
      * [x] Replacement from `new self` to `new MyClass`;
      * [x] Replacement from `self::CONSTANT` to `MyClass::CONSTANT`;
      * [x] Replacement from `self::staticMethod()` to `MyClass::staticMethod()`;
      * [x] Replacement from `self::$staticProperty` to `MyClass::$staticProperty`;
      * [x] Replacement from `__CLASS__` to `MyClass::class`;
* [x] Tests:
  * [x] Tested for false-positive on a long project (about 10.000 found cases);
  * [x] Tests implemented for both ways (default and reverse);
  * [x] Quick-fix and tests implemented for both ways;
* [ ] Text review (_need help here_);

@funivan is copyrighted because of his helpful comments;