### PR TITLE
[#423] Added Laravel debug helpers on ForgottenDebugOutputInspector

### DIFF
--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/debug/ForgottenDebugOutputInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/debug/ForgottenDebugOutputInspector.java
@@ -2,23 +2,37 @@ package com.kalessil.phpStorm.phpInspectionsEA.inspectors.apiUsage.debug;
 
 import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.codeInspection.ProblemsHolder;
-import com.intellij.openapi.util.InvalidDataException;
+import com.intellij.navigation.NavigationItem;
 import com.intellij.openapi.util.Pair;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.util.xmlb.XmlSerializer;
 import com.jetbrains.php.lang.lexer.PhpTokenTypes;
-import com.jetbrains.php.lang.psi.elements.*;
+import com.jetbrains.php.lang.psi.elements.FunctionReference;
+import com.jetbrains.php.lang.psi.elements.Method;
+import com.jetbrains.php.lang.psi.elements.MethodReference;
+import com.jetbrains.php.lang.psi.elements.PhpClass;
+import com.jetbrains.php.lang.psi.elements.PhpClassMember;
+import com.jetbrains.php.lang.psi.elements.PhpPsiElement;
+import com.jetbrains.php.lang.psi.elements.UnaryExpression;
 import com.jetbrains.php.lang.psi.elements.impl.StatementImpl;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
 import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
 import com.kalessil.phpStorm.phpInspectionsEA.options.OptionsComponent;
 import com.kalessil.phpStorm.phpInspectionsEA.utils.OpenapiTypesUtil;
 import org.jdom.Element;
-import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+
+import org.jetbrains.annotations.NotNull;
 
 /*
  * This file is part of the Php Inspections (EA Extended) package.
@@ -30,39 +44,132 @@ import java.util.*;
  */
 
 public class ForgottenDebugOutputInspector extends BasePhpInspection {
-    // Inspection options.
-    public final List<String> configuration = new ArrayList<>();
-    public boolean migratedIntoUserSpace    = false;
+    private static final String message = "Please ensure this is not a forgotten debug statement.";
 
-    final private Set<String> customFunctions                     = new HashSet<>();
-    final private Map<String, Pair<String, String>> customMethods = new HashMap<>();
-    final private Set<String> customMethodsNames                  = new HashSet<>();
+    private static final Map<String, Integer> functionsRequirements = new HashMap<>();
 
-    // prepared content for smooth runtime
-    static private final String message = "Please ensure this is not a forgotten debug statement.";
+    private static final Pattern R_FQN_SPLITTER = Pattern.compile("::");
 
-    public ForgottenDebugOutputInspector() {
+    static {
+        /* function name => amount of arguments considered legal */
+        functionsRequirements.put("debug_print_backtrace", -1);
+        functionsRequirements.put("debug_zval_dump", -1);
+        functionsRequirements.put("phpinfo", 1);
+        functionsRequirements.put("print_r", 2);
+        functionsRequirements.put("var_export", 2);
+        functionsRequirements.put("var_dump", -1);
     }
 
-    public void readSettings(@NotNull Element node) throws InvalidDataException {
+    // Inspection options.
+    public final List<String> configuration = new ArrayList<>();
+    public boolean migratedIntoUserSpace;
+
+    // Custom functions and methods.
+    private final Collection<String>                customFunctions    = new HashSet<>();
+    private final Map<String, Pair<String, String>> customMethods      = new HashMap<>();
+    private final Collection<String>                customMethodsNames = new HashSet<>();
+
+    public void registerCustomDebugMethod(@NotNull final String fqn) {
+        configuration.add(fqn);
+        recompileConfiguration();
+    }
+
+    @NotNull
+    public String getShortName() {
+        return "ForgottenDebugOutputInspection";
+    }
+
+    @Override
+    @NotNull
+    public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder holder, final boolean isOnTheFly) {
+        return new BasePhpElementVisitor() {
+            public void visitPhpMethodReference(final MethodReference reference) {
+                final String methodName = reference.getName();
+
+                if (customMethods.isEmpty() || (methodName == null) || !customMethodsNames.contains(methodName)) {
+                    return;
+                }
+
+                for (final Pair<String, String> match : customMethods.values()) {
+                    final PsiElement resolved = methodName.equals(match.getSecond()) ? reference.resolve() : null;
+
+                    if (resolved instanceof Method) {
+                        final PhpClass clazz = ((PhpClassMember) resolved).getContainingClass();
+
+                        if ((clazz != null) && match.getFirst().equals(clazz.getFQN())) {
+                            holder.registerProblem(reference, message, ProblemHighlightType.GENERIC_ERROR_OR_WARNING);
+                            return;
+                        }
+                    }
+                }
+            }
+
+            public void visitPhpFunctionCall(final FunctionReference reference) {
+                final String functionName = reference.getName();
+
+                if ((functionName != null) && customFunctions.contains(functionName)) {
+                    final Integer paramsNeeded = functionsRequirements.get(functionName);
+
+                    if ((paramsNeeded != null) && (reference.getParameters().length == paramsNeeded)) {
+                        return;
+                    }
+
+                    if (!isBuffered(reference)) {
+                        holder.registerProblem(reference, message, ProblemHighlightType.GENERIC_ERROR_OR_WARNING);
+                    }
+                }
+            }
+
+            private boolean isBuffered(@NotNull final PsiElement debugStatement) {
+                PsiElement parent = debugStatement.getParent();
+
+                /* statement can be prepended by @ (silence) */
+                if (parent instanceof UnaryExpression) {
+                    final PsiElement operation = ((UnaryExpression) parent).getOperation();
+
+                    if ((operation != null) && (operation.getNode().getElementType() == PhpTokenTypes.opSILENCE)) {
+                        parent = parent.getParent();
+                    }
+                }
+
+                boolean result = false;
+
+                /* ensure it's not prepended with 'ob_start();' */
+                if (parent instanceof StatementImpl) {
+                    final PsiElement preceding = ((PhpPsiElement) parent).getPrevPsiSibling();
+
+                    if ((preceding != null) && OpenapiTypesUtil.isFunctionReference(preceding.getFirstChild())) {
+                        final NavigationItem precedingCall         = (NavigationItem) preceding.getFirstChild();
+                        final String         precedingFunctionName = precedingCall.getName();
+
+                        if ("ob_start".equals(precedingFunctionName)) {
+                            result = true;
+                        }
+                    }
+                }
+
+                return result;
+            }
+        };
+    }
+
+    public void readSettings(@NotNull final Element node) {
         XmlSerializer.deserializeInto(this, node);
         recompileConfiguration();
     }
 
-    public void registerCustomDebugMethod(@NotNull String fqn) {
-        this.configuration.add(fqn);
-        this.recompileConfiguration();
+    public JComponent createOptionsPanel() {
+        return OptionsComponent.create((component) -> component.addList("Custom debug methods:", configuration, this::recompileConfiguration));
     }
 
     private void recompileConfiguration() {
-        this.customFunctions.clear();
-        this.customMethods.clear();
-        this.customMethodsNames.clear();
+        customFunctions.clear();
+        customMethods.clear();
+        customMethodsNames.clear();
 
-        final List<String> customDebugFQNs = new ArrayList<>();
-        if (!this.migratedIntoUserSpace) {
+        if (!migratedIntoUserSpace) {
             /* prepare migrated list */
-            final Set<String> migrated = new TreeSet<>();
+            final Collection<String> migrated = new TreeSet<>();
             migrated.add("\\Codeception\\Util\\Debug::pause");
             migrated.add("\\Codeception\\Util\\Debug::debug");
             migrated.add("\\Symfony\\Component\\Debug\\Debug::enable");
@@ -78,116 +185,32 @@ public class ForgottenDebugOutputInspector extends BasePhpInspection {
             migrated.add("print_r");
             migrated.add("var_export");
             migrated.add("var_dump");
-            migrated.addAll(this.configuration);
+            migrated.addAll(configuration);
 
             /* migrate the list */
-            this.configuration.clear();
-            this.configuration.addAll(migrated);
-            this.migratedIntoUserSpace = true;
+            configuration.clear();
+            configuration.addAll(migrated);
+            migratedIntoUserSpace = true;
 
             /* cleanup */
             migrated.clear();
         }
-        customDebugFQNs.addAll(this.configuration);
+
+        final Iterable<String> customDebugFQNs = new ArrayList<>(configuration);
 
         /* parse what was provided FQNs */
         for (String stringDescriptor : customDebugFQNs) {
             stringDescriptor = stringDescriptor.trim();
+
             if (!stringDescriptor.contains("::")) {
                 customFunctions.add(stringDescriptor);
                 continue;
             }
 
-            final String[] disassembledDescriptor = stringDescriptor.split("::", 2);
-            customMethods.put(
-                    stringDescriptor.toLowerCase(),
-                    Pair.create(disassembledDescriptor[0], disassembledDescriptor[1])
-            );
+            final String[] disassembledDescriptor = R_FQN_SPLITTER.split(stringDescriptor, 2);
+
+            customMethods.put(stringDescriptor.toLowerCase(), Pair.create(disassembledDescriptor[0], disassembledDescriptor[1]));
             customMethodsNames.add(disassembledDescriptor[1]);
         }
-    }
-
-    @NotNull
-    public String getShortName() {
-        return "ForgottenDebugOutputInspection";
-    }
-
-    private static final Map<String, Integer> functionsRequirements = new HashMap<>();
-    static {
-        /* function name => amount of arguments considered legal */
-        functionsRequirements.put("debug_print_backtrace", -1);
-        functionsRequirements.put("debug_zval_dump",       -1);
-        functionsRequirements.put("phpinfo",                1);
-        functionsRequirements.put("print_r",                2);
-        functionsRequirements.put("var_export",             2);
-        functionsRequirements.put("var_dump",               -1);
-    }
-
-    @Override
-    @NotNull
-    public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder holder, boolean isOnTheFly) {
-        return new BasePhpElementVisitor() {
-            public void visitPhpMethodReference(MethodReference reference) {
-                final String methodName = reference.getName();
-                if (customMethods.isEmpty() || methodName == null || !customMethodsNames.contains(methodName)) {
-                    return;
-                }
-
-                for (final Pair<String, String> match : customMethods.values()) {
-                    final PsiElement resolved = methodName.equals(match.getSecond()) ? reference.resolve() : null;
-                    if (resolved instanceof Method) {
-                        final PhpClass clazz = ((Method) resolved).getContainingClass();
-                        if (clazz != null && match.getFirst().equals(clazz.getFQN())) {
-                            holder.registerProblem(reference, message, ProblemHighlightType.GENERIC_ERROR_OR_WARNING);
-                            return;
-                        }
-                    }
-                }
-            }
-
-            public void visitPhpFunctionCall(FunctionReference reference) {
-                final String functionName = reference.getName();
-                if (functionName != null && customFunctions.contains(functionName)) {
-                    final Integer paramsNeeded = functionsRequirements.get(functionName);
-                    if (paramsNeeded != null && reference.getParameters().length == paramsNeeded) {
-                        return;
-                    }
-                    if (!this.isBuffered(reference)) {
-                        holder.registerProblem(reference, message, ProblemHighlightType.GENERIC_ERROR_OR_WARNING);
-                    }
-                }
-            }
-
-            private boolean isBuffered(@NotNull PsiElement debugStatement) {
-                boolean result = false;
-
-                PsiElement parent = debugStatement.getParent();
-                /* statement can be prepended by @ (silence) */
-                if (parent instanceof UnaryExpression) {
-                    final PsiElement operation = ((UnaryExpression) parent).getOperation();
-                    if (operation != null && operation.getNode().getElementType() == PhpTokenTypes.opSILENCE) {
-                        parent = parent.getParent();
-                    }
-                }
-                /* ensure it's not prepended with 'ob_start();' */
-                if (parent instanceof StatementImpl) {
-                    final PsiElement preceding = ((StatementImpl) parent).getPrevPsiSibling();
-                    if (preceding != null && OpenapiTypesUtil.isFunctionReference(preceding.getFirstChild())) {
-                        final FunctionReference precedingCall = (FunctionReference) preceding.getFirstChild();
-                        final String precedingFunctionName    = precedingCall.getName();
-                        if (precedingFunctionName != null && precedingFunctionName.equals("ob_start")) {
-                            result = true;
-                        }
-                    }
-                }
-
-                return result;
-            }
-        };
-    }
-
-    public JComponent createOptionsPanel() {
-        return OptionsComponent.create((component)
-                -> component.addList("Custom debug methods:", configuration, this::recompileConfiguration));
     }
 }

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/debug/ForgottenDebugOutputInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/debug/ForgottenDebugOutputInspector.java
@@ -185,6 +185,9 @@ public class ForgottenDebugOutputInspector extends BasePhpInspection {
             migrated.add("print_r");
             migrated.add("var_export");
             migrated.add("var_dump");
+            // Laravel related.
+            migrated.add("dd");
+            migrated.add("dump");
             migrated.addAll(configuration);
 
             /* migrate the list */

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/api/ForgottenDebugOutputInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/api/ForgottenDebugOutputInspectorTest.java
@@ -3,10 +3,10 @@ package com.kalessil.phpStorm.phpInspectionsEA.api;
 import com.kalessil.phpStorm.phpInspectionsEA.PhpCodeInsightFixtureTestCase;
 import com.kalessil.phpStorm.phpInspectionsEA.inspectors.apiUsage.debug.ForgottenDebugOutputInspector;
 
-final public class ForgottenDebugOutputInspectorTest extends PhpCodeInsightFixtureTestCase {
+public final class ForgottenDebugOutputInspectorTest extends PhpCodeInsightFixtureTestCase {
     public void testIfFindsAllPatterns() {
-        ForgottenDebugOutputInspector inspector = new ForgottenDebugOutputInspector();
-        inspector.migratedIntoUserSpace         = false;
+        final ForgottenDebugOutputInspector inspector = new ForgottenDebugOutputInspector();
+        inspector.migratedIntoUserSpace = false;
 
         inspector.registerCustomDebugMethod("my_debug_function");
 
@@ -16,8 +16,8 @@ final public class ForgottenDebugOutputInspectorTest extends PhpCodeInsightFixtu
     }
 
     public void testMethodsNameCollision() {
-        ForgottenDebugOutputInspector inspector = new ForgottenDebugOutputInspector();
-        inspector.migratedIntoUserSpace         = false;
+        final ForgottenDebugOutputInspector inspector = new ForgottenDebugOutputInspector();
+        inspector.migratedIntoUserSpace = false;
 
         inspector.registerCustomDebugMethod("\\DebugClass1::debug");
         inspector.registerCustomDebugMethod("\\DebugClass2::debug");
@@ -28,8 +28,8 @@ final public class ForgottenDebugOutputInspectorTest extends PhpCodeInsightFixtu
     }
 
     public void testFalsePositives() {
-        ForgottenDebugOutputInspector inspector = new ForgottenDebugOutputInspector();
-        inspector.migratedIntoUserSpace         = false;
+        final ForgottenDebugOutputInspector inspector = new ForgottenDebugOutputInspector();
+        inspector.migratedIntoUserSpace = false;
 
         inspector.registerCustomDebugMethod(""); // to force userspace FQNs extension
 

--- a/src/test/resources/fixtures/pitfalls/forgotten-debug-statements.php
+++ b/src/test/resources/fixtures/pitfalls/forgotten-debug-statements.php
@@ -18,3 +18,7 @@
     <error descr="Please ensure this is not a forgotten debug statement.">phpinfo</error>();
 
     <error descr="Please ensure this is not a forgotten debug statement.">my_debug_function</error>();
+
+    // Laravel related.
+    <error descr="Please ensure this is not a forgotten debug statement.">dd</error>();
+    <error descr="Please ensure this is not a forgotten debug statement.">dump</error>();


### PR DESCRIPTION
Was added `dd()` and `dump()`.

PS. I did a code style update (add `final`, weaking types, sorting methods, so on).