### PR TITLE
Don't report over inheritance for yii1 components

### DIFF
--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/classes/LongInheritanceChainInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/classes/LongInheritanceChainInspector.java
@@ -29,6 +29,9 @@ public class LongInheritanceChainInspector extends BasePhpInspection {
         showStoppers.add("\\yii\\base\\Component");
         showStoppers.add("\\yii\\base\\Behavior");
 
+        /* prevents over-inheritance in user space; Yii 1.* */
+        showStoppers.add("\\CComponent");
+
         /* prevents over-inheritance in user space; Zend Framework 2+ */
         showStoppers.add("\\Zend\\Form\\Form");
 


### PR DESCRIPTION
`CComponent` is root class in yii1.