### PR TITLE
Add Drupal debug functions: dpm/dsm, dvm, kpr and dpq to ForgottenDebugOutputInspector

### DIFF
--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/debug/ForgottenDebugOutputInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/debug/ForgottenDebugOutputInspector.java
@@ -113,6 +113,12 @@ public class ForgottenDebugOutputInspector extends BasePhpInspection {
         migrated.add("print_r");
         migrated.add("var_export");
         migrated.add("var_dump");
+        /* Drupal-related debug functions. */
+        migrated.add("dpm");
+        migrated.add("dsm");
+        migrated.add("dvm");
+        migrated.add("kpr");
+        migrated.add("dpq");
 
         return migrated;
     }


### PR DESCRIPTION
Hi Vladimir,
Thanks a lot for this plugin - it simply takes my code to a whole new level!

I work in Drupal projects quite a lot, and use Drupal-specific debug functions (similar to Laravel `dd`) quite a lot. It would be great if they could be marked as Forgotten Debug Output warnings too. I understand one can easily add new functions, but I think they can benefit everyone who uses Drupal with PHPStorm. 

They are global functions (yuck), so I totally understand if you don't feel like adding them to the list and reject this PR. 

Function reference: https://api.drupal.org/api/devel/devel.module/7.x-1.x