### PR TITLE
Fix links

### DIFF
--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/PackedHashtableOptimizationInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/PackedHashtableOptimizationInspector.java
@@ -38,7 +38,7 @@ final public class PackedHashtableOptimizationInspector extends BasePhpInspectio
     @NotNull
     public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder holder, boolean isOnTheFly) {
         return new BasePhpElementVisitor() {
-            /* TODO: docs, http://jpauli.github.io/2016/04/08/hashtables.html#packed-hashtable-optimization */
+            /* TODO: docs, http://blog.jpauli.tech/2016/04/08/hashtables.html#packed-hashtable-optimization */
 
             public void visitPhpArrayCreationExpression(ArrayCreationExpression expression) {
                 /* requires PHP7 */

--- a/src/main/resources/inspectionDescriptions/ClassConstantCanBeUsedInspection.html
+++ b/src/main/resources/inspectionDescriptions/ClassConstantCanBeUsedInspection.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-The feature documentation can be found <a href="http://php.net/manual/en/language.oop5.basic.php#language.oop5.basic.class.class">here</a>.
+The feature documentation can be found <a href="https://secure.php.net/manual/en/language.oop5.basic.php#language.oop5.basic.class.class">here</a>.
 </body>
 </html>

--- a/src/main/resources/inspectionDescriptions/DateTimeConstantsUsageInspection.html
+++ b/src/main/resources/inspectionDescriptions/DateTimeConstantsUsageInspection.html
@@ -1,6 +1,6 @@
 <html>
 <body>
-From the <a href="http://php.net/manual/en/class.datetime.php#datetime.constants.cookie">official documentation</a>:<br/><br/>
+From the <a href="https://secure.php.net/manual/en/class.datetime.php#datetime.constants.cookie">official documentation</a>:<br/><br/>
 
 <b>DateTime::ISO8601</b><br/>
 <b>DATE_ISO8601</b><br/><br/>

--- a/src/main/resources/inspectionDescriptions/ForeachInvariantsInspection.html
+++ b/src/main/resources/inspectionDescriptions/ForeachInvariantsInspection.html
@@ -3,6 +3,6 @@
 Analyzes for-loops and reports if a foreach-loop can be used instead.<br />
 <br />
 Foreach constructs are easier to read and allow the use of efficient
-<a href="http://php.net/manual/en/class.iterator.php">iterators</a>.
+<a href="https://secure.php.net/manual/en/class.iterator.php">iterators</a>.
 </body>
 </html>

--- a/src/main/resources/inspectionDescriptions/PotentialMalwareInspection.html
+++ b/src/main/resources/inspectionDescriptions/PotentialMalwareInspection.html
@@ -1,7 +1,7 @@
 <html>
 <body>
 This is rather a proof of concept, we recommend checking out following projects:<br />
-- https://github.com/gwillem/magento-malware-collection for Magento<br />
+- https://github.com/gwillem/magento-malware-scanner for Magento<br />
 - https://github.com/elcodigok/wphardening for Wordpress<br />
 <br />
 If you aware of similar project for your preferred CMS, please send us a link.

--- a/src/main/resources/inspectionDescriptions/RedundantElseClauseInspection.html
+++ b/src/main/resources/inspectionDescriptions/RedundantElseClauseInspection.html
@@ -15,7 +15,7 @@ Consider the following method:
 In the above, the 'else' statement can be safely removed because its 'if' clause returns from the method.
 Thus, even without the 'else/elseif', there’s no way you’ll be able to proceed past the if clause body.<br />
 <br />
-Please reference to corresponding <a href="http://softwareengineering.stackexchange.com/questions/122485/elegant-ways-to-handle-ifif-else-else">stackoverflow thread</a>
+Please reference to corresponding <a href="https://softwareengineering.stackexchange.com/questions/122485/elegant-ways-to-handle-ifif-else-else">stackoverflow thread</a>
 for more details.
 </body>
 </html>

--- a/src/main/resources/inspectionDescriptions/ReferenceMismatchInspection.html
+++ b/src/main/resources/inspectionDescriptions/ReferenceMismatchInspection.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-Reports reference mismatches (see <a href="http://jpauli.github.io/2014/06/27/references-mismatch.html">details here</a>).
+Reports reference mismatches (see <a href="http://blog.jpauli.tech/2014/06/27/references-mismatch.html">details here</a>).
 </body>
 </html>

--- a/src/main/resources/inspectionDescriptions/ShortListSyntaxCanBeUsedInspection.html
+++ b/src/main/resources/inspectionDescriptions/ShortListSyntaxCanBeUsedInspection.html
@@ -1,7 +1,7 @@
 <html>
 <body>
-See https://wiki.php.net/rfc/short_list_syntax for more info.<br />
-The inspection supports you in migrating to the feature, but IDE might mark resulted code as invalid.
-If so, please vote for supporting this feature: https://youtrack.jetbrains.com/issue/WI-32531
+See <a href="https://wiki.php.net/rfc/short_list_syntax">https://wiki.php.net/rfc/short_list_syntax</a> for more info.<br />
+The inspection supports you in migrating to the feature, but IDE might mark resulted code as invalid (fixed in PHPStorm
+2016.3.3).
 </body>
 </html>

--- a/src/main/resources/inspectionDescriptions/SwitchContinuationInLoopInspection.html
+++ b/src/main/resources/inspectionDescriptions/SwitchContinuationInLoopInspection.html
@@ -1,7 +1,7 @@
 <html>
 <body>
 Analyzes continue usage in switch-case context. Due to PHP's
-<a href="http://php.net/manual/en/control-structures.continue.php">unusual continue syntax</a>, 
+<a href="https://secure.php.net/manual/en/control-structures.continue.php">unusual continue syntax</a>,
 new users who are used to other languages might be confused by its behaviour.
 <!-- tooltip end -->
 <p>
@@ -19,7 +19,7 @@ Covers following case:
 </code>
 
 <p>
-This is PHP-specific and mentioned in <a href="http://php.net/manual/en/control-structures.continue.php">documentation</a>:
+This is PHP-specific and mentioned in <a href="https://secure.php.net/manual/en/control-structures.continue.php">documentation</a>:
 </p>
 
 <blockquote>

--- a/src/main/resources/inspectionDescriptions/ThrowRawExceptionInspection.html
+++ b/src/main/resources/inspectionDescriptions/ThrowRawExceptionInspection.html
@@ -2,6 +2,6 @@
 <body>
 Reports if \Exception has been thrown.<br />
 <br />
-Consider using more specific <a href="http://php.net/manual/en/spl.exceptions.php">SPL exceptions</a>.
+Consider using more specific <a href="https://secure.php.net/manual/en/spl.exceptions.php">SPL exceptions</a>.
 </body>
 </html>

--- a/src/main/resources/inspectionDescriptions/TraitsPropertiesConflictsInspection.html
+++ b/src/main/resources/inspectionDescriptions/TraitsPropertiesConflictsInspection.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-Documentation can be found <a href="https://php.net/manual/en/language.oop5.traits.php#language.oop5.interfaces.examples.ex1">here</a>
+Documentation can be found <a href="https://secure.php.net/manual/en/language.oop5.traits.php#language.oop5.interfaces.examples.ex1">here</a>
 </body>
 </html>


### PR DESCRIPTION
This PR move, where possible, link to HTTPS, fix broken or outdated links and indicate resolution of ShortListSyntaxCanBeUsedInspection bug in PHPStorm 2016.3.3