### PR TITLE
UnqualifiedReferenceInspector: fix message wording

### DIFF
--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/UnqualifiedReferenceInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/UnqualifiedReferenceInspector.java
@@ -32,7 +32,7 @@ import java.util.Set;
  */
 
 public class UnqualifiedReferenceInspector extends BasePhpInspection {
-    private static final String messagePattern = "Using '\\%t%' would enable some of opcache optimizations";
+    private static final String messagePattern = "Using '\\%t%' would enable some of opcode optimizations";
 
     final private static Set<String> falsePositives              = new HashSet<>();
     final private static Map<String, Integer> callbacksPositions = new HashMap<>();
@@ -71,7 +71,7 @@ public class UnqualifiedReferenceInspector extends BasePhpInspection {
     public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder holder, boolean isOnTheFly) {
         return new BasePhpElementVisitor() {
             public void visitPhpFunctionCall(FunctionReference reference) {
-                /* ensure php version is at least PHP 7.0; makes sense only with PHP7+ opcache */
+                /* ensure php version is at least PHP 7.0; makes sense only with PHP7+ opcode */
                 final PhpLanguageLevel phpVersion
                         = PhpProjectConfigurationFacade.getInstance(reference.getProject()).getLanguageLevel();
                 if (phpVersion.compareTo(PhpLanguageLevel.PHP700) >= 0) {
@@ -80,7 +80,7 @@ public class UnqualifiedReferenceInspector extends BasePhpInspection {
                 }
             }
             public void visitPhpConstantReference(ConstantReference reference) {
-                /* ensure php version is at least PHP 7.0; makes sense only with PHP7+ opcache */
+                /* ensure php version is at least PHP 7.0; makes sense only with PHP7+ opcode */
                 final PhpLanguageLevel phpVersion
                         = PhpProjectConfigurationFacade.getInstance(reference.getProject()).getLanguageLevel();
                 if (phpVersion.compareTo(PhpLanguageLevel.PHP700) >= 0) {

--- a/src/test/resources/fixtures/unqualified-function-refs-ns.php
+++ b/src/test/resources/fixtures/unqualified-function-refs-ns.php
@@ -6,17 +6,17 @@ namespace {
 
 namespace Unqualified\References {
 
-    echo <weak_warning descr="Using '\uniqid(...)' would enable some of opcache optimizations">uniqid()</weak_warning>;
-    echo <weak_warning descr="Using '\PHP_INT_MAX' would enable some of opcache optimizations">PHP_INT_MAX</weak_warning>;
+    echo <weak_warning descr="Using '\uniqid(...)' would enable some of opcode optimizations">uniqid()</weak_warning>;
+    echo <weak_warning descr="Using '\PHP_INT_MAX' would enable some of opcode optimizations">PHP_INT_MAX</weak_warning>;
 
-    echo \call_user_func(<weak_warning descr="Using '\my_function' would enable some of opcache optimizations">'my_function'</weak_warning>, '');
-    echo \call_user_func_array(<weak_warning descr="Using '\my_function' would enable some of opcache optimizations">'my_function'</weak_warning>, []);
-    echo \array_filter([], <weak_warning descr="Using '\my_function' would enable some of opcache optimizations">'my_function'</weak_warning>);
-    echo \array_map(<weak_warning descr="Using '\my_function' would enable some of opcache optimizations">'my_function'</weak_warning>, []);
-    echo \array_walk([], <weak_warning descr="Using '\my_function' would enable some of opcache optimizations">'my_function'</weak_warning>);
-    echo \array_reduce([], <weak_warning descr="Using '\my_function' would enable some of opcache optimizations">'my_function'</weak_warning>);
+    echo \call_user_func(<weak_warning descr="Using '\my_function' would enable some of opcode optimizations">'my_function'</weak_warning>, '');
+    echo \call_user_func_array(<weak_warning descr="Using '\my_function' would enable some of opcode optimizations">'my_function'</weak_warning>, []);
+    echo \array_filter([], <weak_warning descr="Using '\my_function' would enable some of opcode optimizations">'my_function'</weak_warning>);
+    echo \array_map(<weak_warning descr="Using '\my_function' would enable some of opcode optimizations">'my_function'</weak_warning>, []);
+    echo \array_walk([], <weak_warning descr="Using '\my_function' would enable some of opcode optimizations">'my_function'</weak_warning>);
+    echo \array_reduce([], <weak_warning descr="Using '\my_function' would enable some of opcode optimizations">'my_function'</weak_warning>);
 
-    echo \array_reduce([], <weak_warning descr="Using '\my_function' would enable some of opcache optimizations">"my_function"</weak_warning>);
+    echo \array_reduce([], <weak_warning descr="Using '\my_function' would enable some of opcode optimizations">"my_function"</weak_warning>);
 
     /* false-positives: a qualified call */
     echo \uniqid();


### PR DESCRIPTION
Afaik it doesn't enable `opcache` optimizations but `opcode` optimizations.