### PR TITLE
Fix stale config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -8,4 +8,3 @@ staleLabel: wontfix
 markComment: >
   Bebo beep, the StaleBot is here. For one year nothing have happened here.
   It would be great if someone looked into details here within next 21 days when I'll close it.
-closeComment: true


### PR DESCRIPTION
`closeComment` must be a string, like `markComment`, otherwise it causes an error and issues will never be closed.