### PR TITLE
Feature #797: avoid backtick operator usage

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -756,6 +756,10 @@ Bug-fixes. BTW, it would be awesome to get more supporters on <a href="https://w
         shortName="InstanceofCanBeUsedInspection"                 displayName="Instanceof can be used"
         groupName="Language level migration"                      enabledByDefault="true" level="WARNING"
         implementationClass="com.kalessil.phpStorm.phpInspectionsEA.inspectors.languageConstructions.InstanceofCanBeUsedInspector"/>
+    <localInspection language="PHP" groupPath="PHP,Php Inspections (EA Extended)"
+        shortName="BacktickOperatorUsageInspection"               displayName="Avoid backtick operator"
+        groupName="Language level migration"                      enabledByDefault="true" level="WARNING"
+        implementationClass="com.kalessil.phpStorm.phpInspectionsEA.inspectors.languageConstructions.BacktickOperatorUsageInspector"/>
 
 
     <localInspection language="PHP" groupPath="PHP,Php Inspections (EA Extended)"

--- a/RULES.md
+++ b/RULES.md
@@ -139,6 +139,7 @@ Inspections Lists (Language level migration)
 | Language level migration | GetClassUsageInspection                         | 'get_class(...)' usage correctness                  | n/a | yes | n/a  | no  |
 | Language level migration | UnsupportedStringOffsetOperationsInspection     | Unsupported string offset operations                | n/a | yes | n/a  | no  |
 | Language level migration | InstanceofCanBeUsedInspection                   | Instanceof can be used                              | yes | yes | yes  | no  |
+| Language level migration | BacktickOperatorUsageInspection                 | Avoid backtick operator                             | yes | yes | yes  | no  |
 
 Inspections Lists (Architecture)
 ---

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/languageConstructions/BacktickOperatorUsageInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/languageConstructions/BacktickOperatorUsageInspector.java
@@ -1,0 +1,94 @@
+package com.kalessil.phpStorm.phpInspectionsEA.inspectors.languageConstructions;
+
+import com.intellij.codeInspection.LocalQuickFix;
+import com.intellij.codeInspection.ProblemDescriptor;
+import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.SmartPointerManager;
+import com.intellij.psi.SmartPsiElementPointer;
+import com.jetbrains.php.lang.psi.PhpPsiElementFactory;
+import com.jetbrains.php.lang.psi.elements.ParenthesizedExpression;
+import com.jetbrains.php.lang.psi.elements.PhpShellCommandExpression;
+import com.jetbrains.php.util.PhpStringUtil;
+import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpElementVisitor;
+import com.kalessil.phpStorm.phpInspectionsEA.openApi.BasePhpInspection;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.regex.Pattern;
+
+/*
+ * This file is part of the Php Inspections (EA Extended) package.
+ *
+ * (c) Vladimir Reznichenko <kalessil@gmail.com>
+ * (c) David Rodrigues <david.proweb@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+public class BacktickOperatorUsageInspector extends BasePhpInspection {
+    static final String message = "Prefer shell_exec() function instead of this backtick operator";
+
+    @NotNull
+    public String getShortName() {
+        return "BacktickOperatorUsageInspection";
+    }
+
+    @Override
+    @NotNull
+    public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder holder, final boolean isOnTheFly) {
+        return new BasePhpElementVisitor() {
+            @Override
+            public void visitPhpShellCommand(@NotNull final PhpShellCommandExpression shellCommandExpression) {
+                holder.registerProblem(shellCommandExpression, message, new UseShellExecQuickFix(shellCommandExpression));
+            }
+        };
+    }
+
+    private static class UseShellExecQuickFix implements LocalQuickFix {
+        private static final Pattern REGEXP_UNESCAPE_BACKTICKS = Pattern.compile("\\\\`");
+
+        private final SmartPsiElementPointer<PhpShellCommandExpression> shellCommandExpressionPointer;
+
+        UseShellExecQuickFix(@NotNull final PhpShellCommandExpression shellCommandExpression) {
+            final SmartPointerManager factory = SmartPointerManager.getInstance(shellCommandExpression.getProject());
+            shellCommandExpressionPointer = factory.createSmartPsiElementPointer(shellCommandExpression);
+        }
+
+        @NotNull
+        @Override
+        public String getName() {
+            return getFamilyName();
+        }
+
+        @NotNull
+        @Override
+        public String getFamilyName() {
+            return "Replace with shell_exec()";
+        }
+
+        @Override
+        public void applyFix(@NotNull final Project project, @NotNull final ProblemDescriptor problemDescriptor) {
+            final PhpShellCommandExpression shellCommandExpression = shellCommandExpressionPointer.getElement();
+
+            if (shellCommandExpression == null) {
+                return;
+            }
+
+            final String shellCommandText              = shellCommandExpression.getText();
+            final String shellCommandTextCutted        = shellCommandText.substring(1, shellCommandText.length() - 1);
+            final String shellCommandBacktickUnescaped = REGEXP_UNESCAPE_BACKTICKS.matcher(shellCommandTextCutted).replaceAll("`");
+            final String shellCommandQuoteEscaped      = PhpStringUtil.escapeText(shellCommandBacktickUnescaped, false);
+
+            final PsiElement shellExecFunctionReference = PhpPsiElementFactory
+                .createPhpPsiFromText(project, ParenthesizedExpression.class, "(shell_exec(\"" + shellCommandQuoteEscaped + "\"))")
+                .getArgument();
+
+            if (shellExecFunctionReference != null) {
+                shellCommandExpression.replace(shellExecFunctionReference);
+            }
+        }
+    }
+}

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/openApi/BasePhpElementVisitor.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/openApi/BasePhpElementVisitor.java
@@ -28,6 +28,8 @@ public abstract class BasePhpElementVisitor extends PhpElementVisitor {
             this.visitPhpDocTag((PhpDocTag) element);
         } else if (element instanceof Declare) {
             this.visitPhpDeclare((Declare) element);
+        } else if (element instanceof PhpShellCommandExpression) {
+            this.visitPhpShellCommand((PhpShellCommandExpression) element);
         } else {
             this.visitElement(element);
         }
@@ -36,6 +38,8 @@ public abstract class BasePhpElementVisitor extends PhpElementVisitor {
     public void visitPhpDeclare(@NotNull Declare declare) {}
     public void visitPhpEval(@NotNull PhpEval eval)       {}
     public void visitPhpDocTag(@NotNull PhpDocTag tag)    {}
+
+    public void visitPhpShellCommand(final PhpShellCommandExpression shellCommandExpression) {}
 
     /* overrides to reduce amount of 'com.jetbrains.php.lang.psi.visitors.PhpElementVisitor.visitElement' calls */
     @Override public void visitPhpFile(PhpFile PhpFile) {}

--- a/src/main/resources/inspectionDescriptions/BacktickOperatorUsageInspection.html
+++ b/src/main/resources/inspectionDescriptions/BacktickOperatorUsageInspection.html
@@ -1,0 +1,5 @@
+<html>
+    <body>
+        Suggests the usage of <code>shell_exec()</code> function instead of backticks operator.
+    </body>
+</html>

--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/lang/BacktickOperatorUsageInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/lang/BacktickOperatorUsageInspectorTest.java
@@ -1,0 +1,17 @@
+package com.kalessil.phpStorm.phpInspectionsEA.lang;
+
+import com.kalessil.phpStorm.phpInspectionsEA.PhpCodeInsightFixtureTestCase;
+import com.kalessil.phpStorm.phpInspectionsEA.inspectors.languageConstructions.BacktickOperatorUsageInspector;
+
+public final class BacktickOperatorUsageInspectorTest extends PhpCodeInsightFixtureTestCase {
+    public void testIfFindsAllPatterns() {
+        myFixture.enableInspections(new BacktickOperatorUsageInspector());
+        myFixture.configureByFile("fixtures/lang/backtick-operator.php");
+        myFixture.testHighlighting(true, false, true);
+
+        myFixture.getAllQuickFixes().forEach(fix -> myFixture.launchAction(fix));
+        myFixture.setTestDataPath(".");
+        myFixture.checkResultByFile("fixtures/lang/backtick-operator.fixed.php");
+    }
+}
+

--- a/src/test/resources/fixtures/lang/backtick-operator.fixed.php
+++ b/src/test/resources/fixtures/lang/backtick-operator.fixed.php
@@ -1,0 +1,6 @@
+<?php
+
+shell_exec("");
+shell_exec("double-quote should be escaped: \"");
+
+echo shell_exec("without space between echo and backtick");

--- a/src/test/resources/fixtures/lang/backtick-operator.php
+++ b/src/test/resources/fixtures/lang/backtick-operator.php
@@ -1,0 +1,6 @@
+<?php
+
+<warning descr="Prefer shell_exec() function instead of this backtick operator">``</warning>;
+<warning descr="Prefer shell_exec() function instead of this backtick operator">`double-quote should be escaped: "`</warning>;
+
+echo<warning descr="Prefer shell_exec() function instead of this backtick operator">`without space between echo and backtick`</warning>;


### PR DESCRIPTION
* 2dfdc9e: inspection implementation;
  * a1321d9: quick-fix implementation;
* 3e806b9: code-style updated;
  * Methods `isTestContext()` and `isFromRootNamespace()` was modifed to be `static`;

It will converts to `shell_exec("double-quoted")` once that single-quotes will not supports variables inside backticks. In future we can try identify better quote style based on backtick contents.