### PR TITLE
Issue #1106 - overwriting methods starting with __ from legacy classes

### DIFF
--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/magicMethods/MagicMethodsValidityInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/magicMethods/MagicMethodsValidityInspector.java
@@ -5,6 +5,8 @@ import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.jetbrains.php.config.PhpLanguageLevel;
+import com.jetbrains.php.lang.psi.elements.ClassReference;
+import com.jetbrains.php.lang.psi.elements.ExtendsList;
 import com.jetbrains.php.lang.psi.elements.Method;
 import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.jetbrains.php.lang.psi.resolve.types.PhpType;
@@ -35,11 +37,14 @@ public class MagicMethodsValidityInspector extends BasePhpInspection {
     private static final PhpType stringType        = (new PhpType()).add(PhpType.STRING);
     private static final PhpType arrayOrNullType   = (new PhpType()).add(PhpType.NULL).add(PhpType.ARRAY);
     private static final Set<String> knownNonMagic = new HashSet<>();
+    private static final Set<String> knownLegacyNonMagicClasses = new HashSet<>();
     static {
         knownNonMagic.add("__inject");
         knownNonMagic.add("__prepare");
         knownNonMagic.add("__toArray");
         knownNonMagic.add("__");
+        knownLegacyNonMagicClasses.add("SoapClient");
+        knownLegacyNonMagicClasses.add("\\SoapClient");
     }
 
     @NotNull
@@ -53,12 +58,15 @@ public class MagicMethodsValidityInspector extends BasePhpInspection {
         return new BasePhpElementVisitor() {
             @Override
             public void visitPhpMethod(@NotNull Method method) {
-                final PhpClass clazz      = method.getContainingClass();
-                final String methodName   = method.getName();
-                final PsiElement nameNode = NamedElementUtil.getNameIdentifier(method);
+                final PhpClass clazz            = method.getContainingClass();
+                final String methodName         = method.getName();
+                final PsiElement nameNode       = NamedElementUtil.getNameIdentifier(method);
+
                 if (clazz == null || nameNode == null || !methodName.startsWith("_") || method.isAbstract()) {
                     return;
                 }
+
+                final ExtendsList clazzParents  = clazz.getExtendsList();
 
                 switch (methodName) {
                     case "__construct":
@@ -142,7 +150,8 @@ public class MagicMethodsValidityInspector extends BasePhpInspection {
                         holder.registerProblem(nameNode, messageUseSplAutoloading, ProblemHighlightType.LIKE_DEPRECATED);
                         break;
                     default:
-                        if (methodName.startsWith("__") && !knownNonMagic.contains(methodName)) {
+                        if (methodName.startsWith("__") && !knownNonMagic.contains(methodName)
+                                && !isLegacyNameFromExtendedClass(clazzParents, method)) {
                             holder.registerProblem(nameNode, messageNotMagic);
                         } else {
                             MissingUnderscoreStrategy.apply(method, holder);
@@ -151,5 +160,22 @@ public class MagicMethodsValidityInspector extends BasePhpInspection {
                 }
             }
         };
+    }
+
+    /**
+     * Returns true if the class extends a Legacy class using "__" methods and the current method is an overwrite
+     * of one of them.
+     * @param clazzParents list of parents for the current class
+     * @param method method being checked
+     * @return boolean
+     */
+    private boolean isLegacyNameFromExtendedClass(ExtendsList clazzParents, Method method) {
+        for (ClassReference className : clazzParents.getReferenceElements()) {
+            if (knownLegacyNonMagicClasses.contains(className.getFQN()) && method.getParent() != null) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
This is my first contribution to a java project, so please be kind! :)

This PR fixes Issue #1106, by creating an array of "legacy" classes that can be tested against the found method. If the current class extends a legacy class and the method has a parent there, then it will not trigger the "Only magic methods should start with '__'" error message.

Hope it helps! :)