### PR TITLE
Improve "Slow array function used in loop" example readablillity

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -30,17 +30,17 @@ Let's start with an example demonstrating the case:
 
 In order to reduce execution time we can modify the code and perform the merge operation only once:
 ```php
-    /* the inner empty array covers cases when no loops were made */
-    $options = [[]];
+    $options = [];
     foreach ($configurationSources as $source) {
         /* something happens here */
         $options[] = $source->getOptions(); // <- yes, we'll use a little bit more memory
     }
+   
     /* PHP below 5.6 */
-    $options = call_user_func_array('array_merge', $options);
+    $options = call_user_func_array('array_merge', [] + $options); // the empty array covers cases when no loops were made
 
     /* PHP 5.6+: more friendly to refactoring as less magic involved */
-    $options = array_merge(...$options);
+    $options = array_merge([], ...$options); // the empty array covers cases when no loops were made
 ```
 
 ## Foreach variables reference usage correctness

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -37,7 +37,7 @@ In order to reduce execution time we can modify the code and perform the merge o
     }
    
     /* PHP below 5.6 */
-    $options = call_user_func_array('array_merge', [] + $options); // the empty array covers cases when no loops were made
+    $options = call_user_func_array('array_merge', $options + [[]]); // the nested empty array covers cases when no loops were made, must be second operand
 
     /* PHP 5.6+: more friendly to refactoring as less magic involved */
     $options = array_merge([], ...$options); // the empty array covers cases when no loops were made


### PR DESCRIPTION
Replace empty array initialization with empty array during the final array_merge call.

This might be controversial and personnel preference but I find the empty array initialization is not obvious  and can better be moved down to the actual `array_merge` call.