### PR TITLE
added support for suppressed placeholders

### DIFF
--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/PrintfScanfArgumentsInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/PrintfScanfArgumentsInspector.java
@@ -55,13 +55,10 @@ public class PrintfScanfArgumentsInspector extends BasePhpInspection {
         functions.put("fscanf",  1);
     }
 
-    final static private Pattern printfRegexPlaceHolders;
-    final static private Pattern scanfRegexPlaceHolders;
-
+    final static private Pattern regexPlaceHolders;
     static {
         // raw regex: %((\d+)\$)?[+-]?(?:[ 0]|\\?'.)?-?\d*(?:\.\d+)?[\[sducoxXbgGeEfF]
-        printfRegexPlaceHolders = Pattern.compile("%((\\d+)\\$)?[+-]?(?:[ 0]|\\\\?'.)?-?\\d*(?:\\.\\d+)?[\\[sducoxXbgGeEfF]");
-        scanfRegexPlaceHolders  = Pattern.compile("%\\*?((\\d+)\\$)?[+-]?(?:[ 0]|\\\\?'.)?-?\\d*(?:\\.\\d+)?[\\[sducoxXbgGeEfF]");
+        regexPlaceHolders = Pattern.compile("%((\\d+|\\*)\\$)?[+-]?(?:[ 0]|\\\\?'.)?-?\\d*(?:\\.\\d+)?[\\[sducoxXbgGeEfF]");
     }
 
     @Override
@@ -102,16 +99,8 @@ public class PrintfScanfArgumentsInspector extends BasePhpInspection {
                         return;
                     }
 
-                    final Matcher regexMatcher = functionName.contains("printf")
-                            ? printfRegexPlaceHolders.matcher(contentAdapted)
-                            : scanfRegexPlaceHolders.matcher(contentAdapted);
+                    final Matcher regexMatcher = regexPlaceHolders.matcher(contentAdapted);
                     while (regexMatcher.find()) {
-                        if (functionName.contains("scanf")) {
-                            String placeholder = contentAdapted.substring(regexMatcher.start(), regexMatcher.end());
-                            if (placeholder.charAt(1) == '*') {
-                                continue;
-                            }
-                        }
                         ++countParsedAll;
 
                         if (null != regexMatcher.group(2)) {

--- a/testData/fixtures/api/printf-scanf.php
+++ b/testData/fixtures/api/printf-scanf.php
@@ -8,6 +8,7 @@ class aClass {
     public function check($arg, $handle) {
         $pattern4 = '%%%%%%%d%d';
         $pattern5 = '[%[^]]]';
+        $pattern6 = '%*s %s';
 
         /* all function reported */
         echo <error descr="Amount of expected parameters is 3.">printf</error> ($pattern4, $arg);
@@ -52,6 +53,9 @@ class aClass {
 
         /* sscanf/fscanf special formats */
         sscanf($arg, $pattern5, $arg);
+
+        /* suppressed placeholders */
+        sscanf($arg, $pattern6, $var2);
     }
 
     public static function test_case_with_modification()


### PR DESCRIPTION
scanf methods also support suppresing placeholder assignment with asterisk. Patterns using asterisk are currently reported as invalid and reported with argument count mismatch.