### PR TITLE
Add PayPal donation link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -2,4 +2,4 @@
 
 github: [kalessil]
 patreon: kalessil
-custom: https://www.paypal.com/paypalme2/VReznichenko
+custom: https://www.paypal.me/VReznichenko

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -2,3 +2,4 @@
 
 github: [kalessil]
 patreon: kalessil
+custom: https://www.paypal.com/paypalme2/VReznichenko


### PR DESCRIPTION
For comapnies it is easier to donate through a single transaction over PayPal than to get the buy-in for a subscription-like donation through Patreon.