### PR TITLE
Remove github since you're not enrolled into sponsorship program

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,3 @@
 # These are supported funding model platforms
 
-github: [kalessil]
 patreon: kalessil


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/47294/66122108-8dc1b880-e5e7-11e9-8aea-2cb43359d065.png)

Since you are not enrolled to GitHub sponsoring program (I'm not aware of a single developer who's enrolled), github is better to be removed from the list.