### PR TITLE
update docs with new syntax permitted with PHP7.4

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -42,6 +42,9 @@ In order to reduce execution time we can modify the code and perform the merge o
 
     /* PHP 5.6+: more friendly to refactoring as less magic involved */
     $options = array_merge([], ...$options); // the empty array covers cases when no loops were made
+    
+    /* PHP 7.4+: array_merge now accepts to be called without arguments. It will work even if $options is empty */
+    $options = array_merge(...$options);
 ```
 
 ## Foreach variables reference usage correctness


### PR DESCRIPTION
Since PHP 7.4, array_merge can be called without any argument:
https://www.php.net/manual/en/function.array-merge.php#refsect1-function.array-merge-changelog

This was made specifically to allow the spread operator to work when the array is empty.

It is now no longer required to add an empty array to the mix