### PR TITLE
Upgrade org.jetbrains.intellij to latest 0.4.15

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 }
 
 plugins {
-    id "org.jetbrains.intellij"   version "0.3.7"
+    id "org.jetbrains.intellij"   version "0.4.15"
     id 'com.palantir.git-version' version "0.11.0"
 }
 


### PR DESCRIPTION
to avoid java.lang.NoClassDefFoundError: javax/xml/bind/JAXBContext on newer jdks