### PR TITLE
Update testData according to PhpStorm Control Flow engine changes

### DIFF
--- a/testData/fixtures/deadCode/parameters-writes-only.php
+++ b/testData/fixtures/deadCode/parameters-writes-only.php
@@ -102,9 +102,9 @@ class Container {
         return $results;
     }
 
-    public function assignment_nodes_proper_targeting() {
+    public function assignment_nodes_proper_targeting($arg) {
         $string = '';
-        if (true) {
+        if ($arg) {
             <weak_warning descr="[EA] Parameter/variable is overridden, but is never used or appears outside of the scope.">$string</weak_warning> .= '';
         } else {
             <weak_warning descr="[EA] Parameter/variable is overridden, but is never used or appears outside of the scope.">$string</weak_warning> .= '';


### PR DESCRIPTION
Hi. Today we're plan to release first PhpStorm 2020.2 EAP. In this version simple "always-false" instructions will not be reachable from control flow entry point anymore, since they're considered as unreachable code (as if there was 'return' for instance). This PR changes testData to make test pass, but please feel free to tune inspection code.