### PR TITLE
Resolve class references from PhpTypeDeclaration rather than from first parameter child

### DIFF
--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/phpUnit/ClassMockingCorrectnessInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/phpUnit/ClassMockingCorrectnessInspector.java
@@ -75,13 +75,16 @@ public class ClassMockingCorrectnessInspector extends BasePhpInspection {
                     for (final Method method : clazz.getOwnMethods()) {
                         for (final Parameter parameter : method.getParameters()) {
                             final PsiElement typeCandidate = parameter.getFirstPsiChild();
-                            if (typeCandidate instanceof ClassReference) {
-                                final PsiElement resolved = OpenapiResolveUtil.resolveReference((ClassReference) typeCandidate);
-                                if (resolved instanceof PhpClass && ((PhpClass) resolved).isFinal()) {
-                                    holder.registerProblem(
-                                            typeCandidate,
-                                            MessagesPresentationUtil.prefixWithEa(messageFinal)
-                                    );
+                            if (typeCandidate instanceof PhpTypeDeclaration) {
+                                for (ClassReference classReference : ((PhpTypeDeclaration) typeCandidate).getClassReferences()) {
+                                    final PsiElement resolved = OpenapiResolveUtil.resolveReference(classReference);
+                                    if (resolved instanceof PhpClass && ((PhpClass) resolved).isFinal()) {
+                                        holder.registerProblem(
+                                                classReference,
+                                                MessagesPresentationUtil.prefixWithEa(messageFinal)
+                                        );
+                                    }
+
                                 }
                             }
                         }


### PR DESCRIPTION
Hi. Today we're plan to release first PhpStorm 2020.2 EAP. In this version we have to make PSI-breaking changes regarding union types support: in parameters and field types all class references in these types will be wrapped into separate `PhpTypeDeclaration` PSI element, so class references should be now fetched from it rather than from parameter.