### PR TITLE
Added $http_response_header to the list of reserved variables

### DIFF
--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/languageConstructions/nullCoalescing/IssetArgumentExistenceInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/languageConstructions/nullCoalescing/IssetArgumentExistenceInspector.java
@@ -40,6 +40,7 @@ public class IssetArgumentExistenceInspector extends BasePhpInspection {
     static {
         specialVariables.add("this");
         specialVariables.add("php_errormsg");
+        specialVariables.add("http_response_header");
     }
 
     @NotNull


### PR DESCRIPTION
Addresses: #1628 

Here is a list of all reserved variables.
https://www.php.net/manual/en/reserved.variables.php

I don't know if any of the other more known variables is affected as well or filtered out differently.