### PR TITLE
Update roave/security-advisories requirement

### DIFF
--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/security/SecurityAdvisoriesInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/security/SecurityAdvisoriesInspector.java
@@ -29,8 +29,8 @@ import java.util.*;
  */
 
 public class SecurityAdvisoriesInspector extends LocalInspectionTool {
-    private static final String message       = "Please add roave/security-advisories:dev-master into require-dev as a firewall for vulnerable components.";
-    private static final String useMaster     = "Please use dev-master instead.";
+    private static final String message       = "Please add roave/security-advisories:dev-latest into require-dev as a firewall for vulnerable components.";
+    private static final String useMaster     = "Please use dev-latest instead.";
     private static final String useRequireDev = "Dev-packages have no security guaranties, invoke the package via require-dev instead.";
 
     // Inspection options.
@@ -262,7 +262,7 @@ public class SecurityAdvisoriesInspector extends LocalInspectionTool {
                             final String packageVersion = pair.getValue().getValue().toLowerCase();
                             if (!packageName.isEmpty() && !packageVersion.isEmpty()) {
                                 if (packageName.equals("roave/security-advisories")) {
-                                    if (!packageVersion.equals("dev-master")) {
+                                    if (!packageVersion.equals("dev-latest")) {
                                         holder.registerProblem(
                                                 pair.getValue(),
                                                 MessagesPresentationUtil.prefixWithEa(useMaster)
@@ -321,7 +321,7 @@ public class SecurityAdvisoriesInspector extends LocalInspectionTool {
                 final JsonProperty developmentRequire = this.developmentRequire == null ? null : this.developmentRequire.getElement();
                 if (developmentRequire == null) {
                     final PsiElement advisories = new JsonElementGenerator(project)
-                            .createObject("\"require-dev\": {\"roave/security-advisories\": \"dev-master\"}")
+                            .createObject("\"require-dev\": {\"roave/security-advisories\": \"dev-latest\"}")
                             .getPropertyList().get(0);
                     productionRequire.getParent().addAfter(advisories, productionRequire);
                     productionRequire.getParent().addAfter(comma, productionRequire);
@@ -330,7 +330,7 @@ public class SecurityAdvisoriesInspector extends LocalInspectionTool {
                     if (packages instanceof JsonObject) {
                         final PsiElement marker     = packages.getFirstChild();
                         final PsiElement advisories = new JsonElementGenerator(project)
-                                .createObject("\"roave/security-advisories\": \"dev-master\"")
+                                .createObject("\"roave/security-advisories\": \"dev-latest\"")
                                 .getPropertyList().get(0);
                         marker.getParent().addAfter(comma, marker);
                         marker.getParent().addAfter(advisories, marker);

--- a/testData/fixtures/securityAdvisories/devDependenciesInProdPackage/composer.json
+++ b/testData/fixtures/securityAdvisories/devDependenciesInProdPackage/composer.json
@@ -2,8 +2,8 @@
   "name":        "kalessil/whatever",
   "description": "",
   "license":     "",
-  <warning descr="[EA] Please add roave/security-advisories:dev-master into require-dev as a firewall for vulnerable components.">"require"</warning>: {
+  <warning descr="[EA] Please add roave/security-advisories:dev-latest into require-dev as a firewall for vulnerable components.">"require"</warning>: {
     <warning descr="[EA] Dev-packages have no security guaranties, invoke the package via require-dev instead.">"phpunit/PHPUnit"</warning>: "*",
-    <warning descr="[EA] Dev-packages have no security guaranties, invoke the package via require-dev instead.">"roave/security-advisories"</warning>: "dev-master"
+    <warning descr="[EA] Dev-packages have no security guaranties, invoke the package via require-dev instead.">"roave/security-advisories"</warning>: "dev-latest"
   }
 }

--- a/testData/fixtures/securityAdvisories/hasAdvisories/composer.json
+++ b/testData/fixtures/securityAdvisories/hasAdvisories/composer.json
@@ -9,6 +9,6 @@
     "vendor/four":  "*"
   },
   "require-dev": {
-     "roave/security-advisories": "dev-master"
+     "roave/security-advisories": "dev-latest"
   }
 }

--- a/testData/fixtures/securityAdvisories/needsAdvisoriesCreatesNewSection/composer.fixed.json
+++ b/testData/fixtures/securityAdvisories/needsAdvisoriesCreatesNewSection/composer.fixed.json
@@ -7,6 +7,6 @@
   }
   ,
   "require-dev": {
-    "roave/security-advisories": "dev-master"
+    "roave/security-advisories": "dev-latest"
   }
 }

--- a/testData/fixtures/securityAdvisories/needsAdvisoriesCreatesNewSection/composer.json
+++ b/testData/fixtures/securityAdvisories/needsAdvisoriesCreatesNewSection/composer.json
@@ -2,7 +2,7 @@
   "name":        "kalessil/whatever",
   "description": "",
   "license":     "",
-  <warning descr="[EA] Please add roave/security-advisories:dev-master into require-dev as a firewall for vulnerable components.">"require"</warning>: {
+  <warning descr="[EA] Please add roave/security-advisories:dev-latest into require-dev as a firewall for vulnerable components.">"require"</warning>: {
     "kalessil-team/something-else": "*"
   }
 }

--- a/testData/fixtures/securityAdvisories/needsAdvisoriesUsesExistingSection/composer.fixed.json
+++ b/testData/fixtures/securityAdvisories/needsAdvisoriesUsesExistingSection/composer.fixed.json
@@ -6,7 +6,7 @@
     "kalessil-team/something-else": "*"
   },
   "require-dev": {
-    "roave/security-advisories": "dev-master"
+    "roave/security-advisories": "dev-latest"
     ,
     "kalessil-team/something-else": "*"
   }

--- a/testData/fixtures/securityAdvisories/needsAdvisoriesUsesExistingSection/composer.json
+++ b/testData/fixtures/securityAdvisories/needsAdvisoriesUsesExistingSection/composer.json
@@ -2,7 +2,7 @@
   "name":        "kalessil/whatever",
   "description": "",
   "license":     "",
-  <warning descr="[EA] Please add roave/security-advisories:dev-master into require-dev as a firewall for vulnerable components.">"require"</warning>: {
+  <warning descr="[EA] Please add roave/security-advisories:dev-latest into require-dev as a firewall for vulnerable components.">"require"</warning>: {
     "kalessil-team/something-else": "*"
   },
   "require-dev": {

--- a/testData/fixtures/securityAdvisories/needsMasterAdvisories/composer.json
+++ b/testData/fixtures/securityAdvisories/needsMasterAdvisories/composer.json
@@ -7,6 +7,6 @@
     "psr/log": "1.0.*"
   },
   "require-dev": {
-    "roave/security-advisories" : <warning descr="[EA] Please use dev-master instead.">"dev-master#commit"</warning>
+    "roave/security-advisories" : <warning descr="[EA] Please use dev-latest instead.">"dev-latest#commit"</warning>
   }
 }


### PR DESCRIPTION
Hello,

I updated the [roave/security-advisories ](https://github.com/Roave/SecurityAdvisories) requirement to use `dev-latest` instead of `dev-master` as it has been changed by the maintainers, cf: https://github.com/Roave/SecurityAdvisories/commit/5ae6aa6482b72946bc0d279c3b54dc1dbeae68d8

Cheers.