### PR TITLE
Allow dev-latest for roave/security-advisories

### DIFF
--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/security/SecurityAdvisoriesInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/security/SecurityAdvisoriesInspector.java
@@ -262,7 +262,7 @@ public class SecurityAdvisoriesInspector extends LocalInspectionTool {
                             final String packageVersion = pair.getValue().getValue().toLowerCase();
                             if (!packageName.isEmpty() && !packageVersion.isEmpty()) {
                                 if (packageName.equals("roave/security-advisories")) {
-                                    if (!packageVersion.equals("dev-master")) {
+                                    if (!packageVersion.equals("dev-master") && !packageVersion.equals("dev-latest")) {
                                         holder.registerProblem(
                                                 pair.getValue(),
                                                 MessagesPresentationUtil.prefixWithEa(useMaster)


### PR DESCRIPTION
`dev-latest` should be valid as well. This is stated in their documentation to use. I think it should be available as alternative.

See: https://github.com/Roave/SecurityAdvisories

I know this is pretty similar to #1647, although this would have less impact as existing configurations still work.