### PR TITLE
Update ShortEchoTagCanBeUsedInspector.java

### DIFF
--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeStyle/ShortEchoTagCanBeUsedInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/codeStyle/ShortEchoTagCanBeUsedInspector.java
@@ -28,7 +28,7 @@ import java.util.stream.Stream;
  */
 
 public class ShortEchoTagCanBeUsedInspector extends BasePhpInspection {
-    private static final String message = "'<?= ... ?>' could be used instead (but ensure that short_open_tag is enabled).";
+    private static final String message = "'<?= ... ?>' could be used instead.";
 
     @NotNull
     @Override


### PR DESCRIPTION
Just removing the incorrect message. Disabling short_open_tag does not disable short echo tag.