### PR TITLE
Write unit tests for name identifiers in json_decode

### DIFF
--- a/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/api/JsonEncodingApiUsageInspectorTest.java
+++ b/src/test/java/com/kalessil/phpStorm/phpInspectionsEA/api/JsonEncodingApiUsageInspectorTest.java
@@ -38,4 +38,21 @@ final public class JsonEncodingApiUsageInspectorTest extends PhpCodeInsightFixtu
             myFixture.checkResultByFile("testData/fixtures/api/json-encoding-errors-handling.fixed.php");
         }
     }
+    public void testItRecognizesNameIdentifierFlags() {
+        final PhpLanguageLevel level = PhpLanguageLevel.parse("8.0");
+        if (level != null && level.getVersionString().equals("8.0")) {
+            PhpProjectConfigurationFacade.getInstance(myFixture.getProject()).setLanguageLevel(level);
+            final JsonEncodingApiUsageInspector inspector = new JsonEncodingApiUsageInspector();
+            inspector.HARDEN_DECODING_RESULT_TYPE = false;
+            inspector.HARDEN_ERRORS_HANDLING      = true;
+
+            myFixture.enableInspections(inspector);
+            myFixture.configureByFile("testData/fixtures/api/json-encoding-errors-handling.80.php");
+            myFixture.testHighlighting(true, false, true);
+
+            myFixture.getAllQuickFixes().forEach(fix -> myFixture.launchAction(fix));
+            myFixture.setTestDataPath(".");
+            myFixture.checkResultByFile("testData/fixtures/api/json-encoding-errors-handling.80.fixed.php");
+        }
+    }
 }

--- a/testData/fixtures/api/json-encoding-errors-handling.80.fixed.php
+++ b/testData/fixtures/api/json-encoding-errors-handling.80.fixed.php
@@ -1,0 +1,13 @@
+<?php
+
+function cases_holder($encoded, $options) {
+    $local = JSON_THROW_ON_ERROR;
+
+    return [
+        json_decode(json: $encoded, flags: JSON_THROW_ON_ERROR),
+        json_decode($encoded, flags: JSON_THROW_ON_ERROR),
+        json_decode($encoded, false, flags: JSON_THROW_ON_ERROR),
+        json_decode($encoded, false, 512, flags: JSON_THROW_ON_ERROR),
+        json_decode($encoded, flags: $options | JSON_THROW_ON_ERROR),
+    ];
+}

--- a/testData/fixtures/api/json-encoding-errors-handling.80.php
+++ b/testData/fixtures/api/json-encoding-errors-handling.80.php
@@ -1,0 +1,13 @@
+<?php
+
+function cases_holder($encoded, $options) {
+    $local = JSON_THROW_ON_ERROR;
+
+    return [
+        json_decode(json: $encoded, flags: JSON_THROW_ON_ERROR),
+        json_decode($encoded, flags: JSON_THROW_ON_ERROR),
+        json_decode($encoded, false, flags: JSON_THROW_ON_ERROR),
+        json_decode($encoded, false, 512, flags: JSON_THROW_ON_ERROR),
+        json_decode($encoded, flags: $options | JSON_THROW_ON_ERROR),
+    ];
+}


### PR DESCRIPTION
Pull request regarding #1725 
I built failing test cases, but unfortunately, like [niconoe-](https://github.com/niconoe-), I'm not a Java developer and can't make the time right now to figure out how to run this project, run the unit tests, and how to get argument names from a PsiElement.

It should be a relatively simple fix to check for an argument name from the `arguments` list in [JsonEncodingApiUsageInspector.java](https://github.com/kalessil/phpinspectionsea/blob/ad57a4a557daff9fa97df654c467ac5048c2379b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/JsonEncodingApiUsageInspector.java#L78-L95).

Oh well, hopefully this is somewhat useful and otherwise feel free to decline.
