### PR TITLE
Add `is_scalar`, `sizeof`, `ini_get` and `sprintf` to list of compiled/optimized functions

### DIFF
--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/UnqualifiedReferenceInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/UnqualifiedReferenceInspector.java
@@ -111,6 +111,9 @@ public class UnqualifiedReferenceInspector extends BasePhpInspection {
         advancedOpcode.add("constant");
         advancedOpcode.add("define");
         advancedOpcode.add("array_key_exists");
+        advancedOpcode.add("is_scalar");
+        advancedOpcode.add("sizeof");
+        advancedOpcode.add("ini_get");
     }
 
     final private static Condition<PsiElement> PARENT_NAMESPACE = new Condition<PsiElement>() {

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/UnqualifiedReferenceInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/UnqualifiedReferenceInspector.java
@@ -114,6 +114,7 @@ public class UnqualifiedReferenceInspector extends BasePhpInspection {
         advancedOpcode.add("is_scalar");
         advancedOpcode.add("sizeof");
         advancedOpcode.add("ini_get");
+        advancedOpcode.add("sprintf");
     }
 
     final private static Condition<PsiElement> PARENT_NAMESPACE = new Condition<PsiElement>() {


### PR DESCRIPTION
See FriendsOfPHP/PHP-CS-Fixer#6277