### PR TITLE
Fix incorrect usage of "amount" instead of "number"

### DIFF
--- a/.travis/verify-discovered-values-cleanup.php
+++ b/.travis/verify-discovered-values-cleanup.php
@@ -10,7 +10,7 @@
             $fileContent = file_get_contents($file->getPathname());
             preg_match_all('/([ ]+)(final[ ]+)?[a-z<>]+[ ]+([a-z]+)[ ]+=\s+PossibleValuesDiscoveryUtil\s*\.\s*discover\(/ims', $fileContent, $discovery);
             if ($discovery[0] !== []) {
-                /* match amount of calls */
+                /* match number of calls */
                 preg_match_all('/([ ]+)('.implode('|', $discovery[3]).')\.clear\(/ims', $fileContent, $clearing);
                 if (count($discovery[0]) !== count($clearing[0])) {
                     $missingClear []= $file->getFilename();

--- a/docs/control-flow.md
+++ b/docs/control-flow.md
@@ -77,7 +77,7 @@ Php Inspections (EA Extended) friendly way:
 ## If-return-return could be simplified
 
 The inspection finds places where conditional return-statements can be simplified (by Quick-Fixing), reducing code 
-complexity metrics and amount of maintainable codebase. 
+complexity metrics and size of maintainable codebase.
 
 ```php
     /* before */

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/PrintfScanfArgumentsInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/PrintfScanfArgumentsInspector.java
@@ -32,7 +32,7 @@ import java.util.regex.Pattern;
 
 public class PrintfScanfArgumentsInspector extends BasePhpInspection {
     private static final String messagePattern    = "Pattern seems to be not valid.";
-    private static final String messageParameters = "Amount of expected parameters is %c%.";
+    private static final String messageParameters = "Number of expected parameters is %c%.";
 
     @NotNull
     @Override

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/debug/ForgottenDebugOutputInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/debug/ForgottenDebugOutputInspector.java
@@ -183,7 +183,7 @@ public class ForgottenDebugOutputInspector extends BasePhpInspection {
 
     private static final Map<String, Integer> functionsRequirements = new HashMap<>();
     static {
-        /* function name => amount of arguments considered legal */
+        /* function name => number of arguments considered legal */
         functionsRequirements.put("debug_print_backtrace", -1);
         functionsRequirements.put("debug_zval_dump",       -1);
         functionsRequirements.put("phpinfo",                1);

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/fileSystem/CascadingDirnameCallsInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/apiUsage/fileSystem/CascadingDirnameCallsInspector.java
@@ -29,7 +29,7 @@ import java.util.List;
  */
 
 public class CascadingDirnameCallsInspector extends BasePhpInspection {
-    private static final String messagePattern = "'%e%' can be used instead (reduces amount of calls).";
+    private static final String messagePattern = "'%e%' can be used instead (reduces number of calls).";
 
     @NotNull
     @Override

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/classes/SenselessMethodDuplicationInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/classes/SenselessMethodDuplicationInspector.java
@@ -70,7 +70,7 @@ public class SenselessMethodDuplicationInspector extends BasePhpInspection {
                     return;
                 }
 
-                /* ensure parent, parent methods are existing and contains the same amount of expressions */
+                /* ensure parent, parent methods are existing and contains the same number of expressions */
                 final PhpClass parent           = OpenapiResolveUtil.resolveSuperClass(clazz);
                 final Method parentMethod       = null == parent ? null : OpenapiResolveUtil.resolveMethod(parent, method.getName());
                 if (parentMethod == null || parentMethod.isAbstract() || parentMethod.isDeprecated() || parentMethod.getModifier().isPrivate()) {

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/classes/SenselessProxyMethodInspector.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/inspectors/semanticalAnalysis/classes/SenselessProxyMethodInspector.java
@@ -123,7 +123,7 @@ public class SenselessProxyMethodInspector extends BasePhpInspection {
                             final Method nestedMethod          = (Method) referenceResolved;
                             final Parameter[] parentParameters = nestedMethod.getParameters();
 
-                            /* verify amount of parameters, visibility, static, abstract, final */
+                            /* verify number of parameters, visibility, static, abstract, final */
                             if (
                                 parentParameters.length   == methodParameters.length &&
                                 nestedMethod.isAbstract() == method.isAbstract() &&

--- a/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/openApi/BasePhpElementVisitor.java
+++ b/src/main/java/com/kalessil/phpStorm/phpInspectionsEA/openApi/BasePhpElementVisitor.java
@@ -49,7 +49,7 @@ public abstract class BasePhpElementVisitor extends PhpElementVisitor {
     public void visitPhpShellCommand(@NotNull PhpShellCommandExpression expression) {}
     public void visitPhpThrowExpression(@NotNull PhpThrowExpression expression)     {}
 
-    /* overrides to reduce amount of 'com.jetbrains.php.lang.psi.visitors.PhpElementVisitor.visitElement' calls */
+    /* overrides to reduce number of 'com.jetbrains.php.lang.psi.visitors.PhpElementVisitor.visitElement' calls */
     @Override public void visitPhpFile(PhpFile PhpFile)        {}
     @Override public void visitWhiteSpace(PsiWhiteSpace space) {}
 

--- a/testData/fixtures/api/cascade-dirname.php
+++ b/testData/fixtures/api/cascade-dirname.php
@@ -1,9 +1,9 @@
 <?php
 
-    <warning descr="[EA] 'dirname(__DIR__, 3)' can be used instead (reduces amount of calls).">dirname(dirname(dirname(__DIR__)))</warning>;
-    <warning descr="[EA] 'dirname(trim(__DIR__), 3)' can be used instead (reduces amount of calls).">dirname(dirname(dirname(trim(__DIR__))))</warning>;
-    <warning descr="[EA] 'dirname(__DIR__, 1 + $level)' can be used instead (reduces amount of calls).">dirname(dirname(__DIR__, $level))</warning>;
-    <warning descr="[EA] 'dirname(__DIR__, 3)' can be used instead (reduces amount of calls).">dirname(dirname(__DIR__, 1), 2)</warning>;
+    <warning descr="[EA] 'dirname(__DIR__, 3)' can be used instead (reduces number of calls).">dirname(dirname(dirname(__DIR__)))</warning>;
+    <warning descr="[EA] 'dirname(trim(__DIR__), 3)' can be used instead (reduces number of calls).">dirname(dirname(dirname(trim(__DIR__))))</warning>;
+    <warning descr="[EA] 'dirname(__DIR__, 1 + $level)' can be used instead (reduces number of calls).">dirname(dirname(__DIR__, $level))</warning>;
+    <warning descr="[EA] 'dirname(__DIR__, 3)' can be used instead (reduces number of calls).">dirname(dirname(__DIR__, 1), 2)</warning>;
 
     /* false-positives */
     dirname(realpath(__DIR__), 2);

--- a/testData/fixtures/api/printf-scanf.php
+++ b/testData/fixtures/api/printf-scanf.php
@@ -11,20 +11,20 @@ class aClass {
         $pattern6 = '%*s %s';
 
         /* all function reported */
-        echo <error descr="[EA] Amount of expected parameters is 3.">printf</error> ($pattern4, $arg);
-        echo <error descr="[EA] Amount of expected parameters is 3.">sprintf</error> ($pattern4, $arg);
-        echo <error descr="[EA] Amount of expected parameters is 4.">fprintf</error> ($handle, $pattern4, $arg);
-        echo <error descr="[EA] Amount of expected parameters is 4.">sscanf</error> ($arg, $pattern4, $arg);
-        echo <error descr="[EA] Amount of expected parameters is 4.">fscanf</error> ($handle, $pattern4, $arg);
+        echo <error descr="[EA] Number of expected parameters is 3.">printf</error> ($pattern4, $arg);
+        echo <error descr="[EA] Number of expected parameters is 3.">sprintf</error> ($pattern4, $arg);
+        echo <error descr="[EA] Number of expected parameters is 4.">fprintf</error> ($handle, $pattern4, $arg);
+        echo <error descr="[EA] Number of expected parameters is 4.">sscanf</error> ($arg, $pattern4, $arg);
+        echo <error descr="[EA] Number of expected parameters is 4.">fscanf</error> ($handle, $pattern4, $arg);
 
         /* sscanf/fscanf with partially provided containers */
-        list($first, $second) = <error descr="[EA] Amount of expected parameters is 4.">sscanf</error> ($arg, $pattern4, $first);
-        list($first, $second) = <error descr="[EA] Amount of expected parameters is 4.">fscanf</error> ($handle, $pattern4, $first);
+        list($first, $second) = <error descr="[EA] Number of expected parameters is 4.">sscanf</error> ($arg, $pattern4, $first);
+        list($first, $second) = <error descr="[EA] Number of expected parameters is 4.">fscanf</error> ($handle, $pattern4, $first);
 
         /* test resolving string literal */
-        echo <error descr="[EA] Amount of expected parameters is 3.">sprintf</error> (self::PATTERN1, $arg);
-        echo <error descr="[EA] Amount of expected parameters is 3.">sprintf</error> (self::$pattern2, $arg);
-        echo <error descr="[EA] Amount of expected parameters is 3.">sprintf</error> ($this->pattern3, $arg);
+        echo <error descr="[EA] Number of expected parameters is 3.">sprintf</error> (self::PATTERN1, $arg);
+        echo <error descr="[EA] Number of expected parameters is 3.">sprintf</error> (self::$pattern2, $arg);
+        echo <error descr="[EA] Number of expected parameters is 3.">sprintf</error> ($this->pattern3, $arg);
         echo sprintf(<error descr="[EA] Pattern seems to be not valid.">'%'</error>, $arg);
 
 

--- a/testData/fixtures/lang/variable-functions-php53.php
+++ b/testData/fixtures/lang/variable-functions-php53.php
@@ -2,7 +2,7 @@
 
     /*
     TODO: (configurable) call_user_func's first parameter validation
-    TODO: (configurable) amount of arguments validation for resolved methods/functions
+    TODO: (configurable) number of arguments validation for resolved methods/functions
     */
 
     class ClassVFParent {


### PR DESCRIPTION
Many user messages incorrectly use the word "amount" where "number" belongs. See [Understanding The Difference Between Number and Amount](https://www.enago.com/academy/understanding-the-difference-between-number-and-amount/#:~:text=Although%20number%20and%20amount%20have,at%20the%20noun%20being%20described.). It's a niggle, but it distracts me a little every time I see it. 😛 It's just a string change, so hopefully it doesn't break any tests.