### PR TITLE
Update org.jetbrains.intellij to v1.13.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     // Kotlin support
     id("org.jetbrains.kotlin.jvm") version "1.8.10"
     // Gradle IntelliJ Plugin
-    id("org.jetbrains.intellij") version "1.13.0"
+    id("org.jetbrains.intellij") version "1.13.1"
     // Gradle Changelog Plugin
     id("org.jetbrains.changelog") version "1.3.1"
     // Gradle Qodana Plugin


### PR DESCRIPTION
To resolve "Unsupported JVM architecture was selected for running Gradle tasks: x86_64. Supported architectures: amd64, aarch64" error

More info: https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/1317